### PR TITLE
java.lang.UnsupportedOperationException: Unknown Collection type

### DIFF
--- a/cloverage/src/cloverage/instrument.clj
+++ b/cloverage/src/cloverage/instrument.clj
@@ -16,7 +16,8 @@
   [start form]
   (if (iobj? form)
     (let [line (or (:line (meta form)) start)
-          recs (if (seq? form)
+          recs (if (and (seq? form) (seq form))
+                 ;; (seq '()) gives nil which makes us NPE. Bad.
                  (seq (map (partial propagate-line-numbers line) form))
                  form)
           ret  (if line

--- a/cloverage/src/cloverage/sample.clj
+++ b/cloverage/src/cloverage/sample.clj
@@ -16,6 +16,10 @@
 {:a (+ 1 2)
  (/ 4 2) "two"}
 
+(defn function-with-empty-list []
+  ;; used to break stuff - see issues #14 and #17
+  '())
+
 (defn not-covered-at-all
   "This function is not covered at all"
   [arg1 arg2]


### PR DESCRIPTION
No clear idea what's going on here:

```
Exception in thread "main" java.lang.Exception: Couldn't eval form (...)
(defn cut-stream-on-flag [stream flag]
  "returns a lazy sequence which wraps the passed in stream. Each
   time an element is taken, we check flag. If flag is false, we
   end the sequence.\n\n   Basically the idea is that this will turn an infinite (usually
   io-bound) sequence into a finite one which ends when we say it
   ends."
  (lazy-seq (if (and (clojure.core/deref flag) (seq stream))
                  (cons (first stream) (cut-stream-on-flag (rest stream) flag))
                  (quote ()))))

    at cloverage.instrument$instrument$fn__515.invoke(instrument.clj:325)
    at cloverage.instrument$instrument.invoke(instrument.clj:315)
(...)
Caused by: java.lang.UnsupportedOperationException: Unknown Collection type, compiling:(com/loggly/metamorphosis/utils.clj:26)
    at clojure.lang.Compiler.analyzeSeq(Compiler.java:6462)
    at clojure.lang.Compiler.analyze(Compiler.java:6262)
    at clojure.lang.Compiler.analyze(Compiler.java:6223)
    at clojure.lang.Compiler$BodyExpr$Parser.parse(Compiler.java:5618)
    at clojure.lang.Compiler.analyzeSeq(Compiler.java:6455)
    at clojure.lang.Compiler.analyze(Compiler.java:6262)
    at clojure.lang.Compiler.analyzeSeq(Compiler.java:6443)
    at clojure.lang.Compiler.analyze(Compiler.java:6262)
    at clojure.lang.Compiler.analyze(Compiler.java:6223)
    at clojure.lang.Compiler$NewExpr$Parser.parse(Compiler.java:2478)
    at clojure.lang.Compiler.analyzeSeq(Compiler.java:6455)
    at clojure.lang.Compiler.analyze(Compiler.java:6262)
    at clojure.lang.Compiler.analyze(Compiler.java:6223)
    at clojure.lang.Compiler$BodyExpr$Parser.parse(Compiler.java:5618)
    at clojure.lang.Compiler.analyzeSeq(Compiler.java:6455)
    at clojure.lang.Compiler.analyze(Compiler.java:6262)
    at clojure.lang.Compiler.analyzeSeq(Compiler.java:6443)
    at clojure.lang.Compiler.analyze(Compiler.java:6262)
    at clojure.lang.Compiler.analyze(Compiler.java:6223)
    at clojure.lang.Compiler$BodyExpr$Parser.parse(Compiler.java:5618)
    at clojure.lang.Compiler$FnMethod.parse(Compiler.java:5054)
    at clojure.lang.Compiler$FnExpr.parse(Compiler.java:3674)
    at clojure.lang.Compiler.analyzeSeq(Compiler.java:6453)
    at clojure.lang.Compiler.analyze(Compiler.java:6262)
    at clojure.lang.Compiler.analyzeSeq(Compiler.java:6443)
    at clojure.lang.Compiler.analyze(Compiler.java:6262)
    at clojure.lang.Compiler.access$100(Compiler.java:37)
    at clojure.lang.Compiler$DefExpr$Parser.parse(Compiler.java:518)
    at clojure.lang.Compiler.analyzeSeq(Compiler.java:6455)
    at clojure.lang.Compiler.analyze(Compiler.java:6262)
    at clojure.lang.Compiler.analyze(Compiler.java:6223)
    at clojure.lang.Compiler.eval(Compiler.java:6515)
    at clojure.lang.Compiler.eval(Compiler.java:6501)
    at clojure.lang.Compiler.eval(Compiler.java:6477)
    at clojure.core$eval.invoke(core.clj:2797)
    at cloverage.instrument$instrument$fn__515$fn__516.invoke(instrument.clj:318)
    at cloverage.instrument$instrument$fn__515.invoke(instrument.clj:316)
    ... 20 more
Caused by: java.lang.UnsupportedOperationException: Unknown Collection type
    at clojure.lang.Compiler$EmptyExpr.emit(Compiler.java:2730)
    at clojure.lang.Compiler$BodyExpr.emit(Compiler.java:5662)
    at clojure.lang.Compiler$IfExpr.doEmit(Compiler.java:2593)
    at clojure.lang.Compiler$IfExpr.emit(Compiler.java:2544)
    at clojure.lang.Compiler$BodyExpr.emit(Compiler.java:5662)
    at clojure.lang.Compiler$BodyExpr.emit(Compiler.java:5662)
    at clojure.lang.Compiler$FnMethod.doEmit(Compiler.java:5215)
    at clojure.lang.Compiler$FnMethod.emit(Compiler.java:5069)
    at clojure.lang.Compiler$FnExpr.emitMethods(Compiler.java:3600)
    at clojure.lang.Compiler$ObjExpr.compile(Compiler.java:4233)
    at clojure.lang.Compiler$FnExpr.parse(Compiler.java:3732)
    at clojure.lang.Compiler.analyzeSeq(Compiler.java:6453)
    ... 56 more
```
