### PR TITLE
Cloverage leaking its dependencies onto the tested classpath causes crash

### DIFF
--- a/cloverage/project.clj
+++ b/cloverage/project.clj
@@ -5,7 +5,7 @@
         :dir  ".."
         :url  "https://www.github.com/lshift/cloverage"
         :tag  "HEAD"}
-  :main cloverage.coverage
+  :main ^:skip-aot cloverage.coverage
   :license {:name "Eclipse Public License - v 1.0"
             :url "http://www.eclipse.org/legal/epl-v10.html"
             :distribution :repo


### PR DESCRIPTION
We do not isolate the tested project from our dependencies, which can cause confusing behaviour. See JacekLach/cloverage#24 for previous discussion.

For some reason this only happens on 1.0.4-SNAPSHOT.

Repro:
`project.clj`

``` clojure
(defproject cloverage-bug "0.1.0-SNAPSHOT"
  :description "FIXME: write description"
  :url "http://example.com/FIXME"
  :license {:name "Eclipse Public License"
            :url "http://www.eclipse.org/legal/epl-v10.html"}
  :dependencies [[org.clojure/clojure "1.5.1"]
                 [org.clojure/tools.cli "0.3.1"]])
```

`src/cloverage-bug/core.clj`

``` clojure
(ns cloverage-hack.core
  (:require [clojure.tools.cli :refer [parse-opts]]))

(defn foo
  "I don't do a whole lot."
  [x]
  (println x "Hello, World!"))
```

We use `tools.cli "0.2.2"`, which does not have the `parse-opts` function. 

```
$ CLOVERAGE_VERSION=1.0.4-SNAPSHOT lein cloverage
Loading namespaces:  (cloverage-hack.core)
Test namespaces:  ()
Exception in thread "main" java.lang.IllegalAccessError: parse-opts does not exist
```

1.0.3 works fine.
