### PR TITLE
rewrite for/doseq to skip chunked path

### DIFF
--- a/cloverage/src/cloverage/instrument.clj
+++ b/cloverage/src/cloverage/instrument.clj
@@ -361,14 +361,7 @@
                     body))))
 
 (defmethod do-wrap :for [f line form env]
-  (tprnl "Wrapping " (class form) form)
-  (let [expanded (unchunk form)]
-    (tprnl "Expanded" form "into" expanded)
-    (tprnl "Meta on expanded is" (meta expanded))
-    (if (= :list (form-type expanded env))
-      (let [wrapped (doall (map (wrapper f line) expanded))]
-        (f line (add-original form wrapped)))
-      (wrap f line (add-original form expanded)))))
+  (do-wrap f line (unchunk form) env))
 
 (defmethod do-wrap :list [f line form env]
   (tprnl "Wrapping " (class form) form)

--- a/cloverage/src/cloverage/rewrite.clj
+++ b/cloverage/src/cloverage/rewrite.clj
@@ -1,0 +1,54 @@
+(ns cloverage.rewrite)
+
+(defn better-empty [x]
+  (with-meta
+    (if (instance? clojure.lang.IMapEntry x)
+      []
+      (empty x))
+    (meta x)))
+
+(defn better-into [e s]
+  (if (list? e)
+    (with-meta
+      (seq s)
+      (meta e))
+    (into e s)))
+
+(defn walk
+  [inner outer form]
+  (if (coll? form)
+    (let [e (better-empty form)
+          contents (map inner form)]
+      (outer (better-into e contents)))
+    (outer form)))
+
+(defn postwalk
+  [f form]
+  (walk (partial postwalk f) f form))
+
+(defn prewalk
+  [f form]
+  (walk (partial prewalk f) identity (f form)))
+
+
+(defn do-walk [pred f forms]
+  (prewalk
+    (fn [x] (if (pred x) (f x) x))
+    forms))
+
+(defn cs? [s]
+  (chunked-seq? s))
+
+(defn chunked-if? [form]
+  (and
+    (seq? form)
+    (= (first form) 'if)
+    (seq? (second form))
+    (= (first (second form)) `chunked-seq?)))
+
+(defn unchunk [forms]
+  (->>
+    forms
+    (do-walk `#{chunked-seq?} (constantly `cs?))
+    macroexpand
+    (do-walk chunked-if? #(nth % 3))))


### PR DESCRIPTION
for/doseq expand inline to code with a chunked and an unchunked path.

Usually only one is exercised by unit tests, so coverage results are
lower than one would expect, given that all the logic *in* the for loop
has been tested.

By removing the chunked path during macro expansion, we can fix this.

Fixes #23 