### PR TITLE
Add junit xml support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Remove the self-reference and the test coverage report should report correctly a
 1.0.8 (WIP)
 - Features
   - Add [Code of Conduct](https://github.com/cloverage/cloverage/blob/master/CODE_OF_CONDUCT.md) (#128)
+  - Add junit support with the `--junit` flag (#127)
 
 1.0.7
 - Features

--- a/cloverage/src/cloverage/coverage.clj
+++ b/cloverage/src/cloverage/coverage.clj
@@ -86,55 +86,55 @@
 
 (defn parse-args [args]
   (cli/cli args
-       ["-o" "--output" "Output directory." :default "target/coverage"]
-       ["--[no-]text"
-        "Produce a text report." :default false]
-       ["--[no-]html"
-        "Produce an HTML report." :default true]
-       ["--[no-]emma-xml"
-        "Produce an EMMA XML report. [emma.sourceforge.net]" :default false]
-       ["--[no-]lcov"
-        "Produce a lcov/gcov report." :default false]
-       ["--[no-]codecov"
-        "Generate a JSON report for Codecov.io" :default false]
-       ["--[no-]coveralls"
-        "Send a JSON report to Coveralls if on a CI server" :default false]
-       ["--[no-]junit"
-        "Output test results as junit xml file. Supported in :clojure.test runner" :default false]
-       ["--[no-]raw"
-        "Output raw coverage data (for debugging)." :default false]
-       ["--[no-]summary"
-        "Prints a summary" :default true]
-       ["-d" "--[no-]debug"
-        "Output debugging information to stdout." :default false]
-       ["-r" "--runner"
-        "Specify which test runner to use. Currently supported runners are `clojure.test` and `midje`."
-        :default :clojure.test
-        :parse-fn parse-kw-str]
-       ["--[no-]nop" "Instrument with noops." :default false]
-       ["-n" "--ns-regex"
-        "Regex for instrumented namespaces (can be repeated)."
-        :default  []
-        :parse-fn (collecting-args-parser)]
-       ["-e" "--ns-exclude-regex"
-        "Regex for namespaces not to be instrumented (can be repeated)."
-        :default  []
-        :parse-fn (collecting-args-parser)]
-       ["-t" "--test-ns-regex"
-        "Regex for test namespaces (can be repeated)."
-        :default []
-        :parse-fn (collecting-args-parser)]
-       ["-p" "--src-ns-path"
-        "Path (string) to directory containing source code namespaces."
-        :default nil]
-       ["-s" "--test-ns-path"
-        "Path (string) to directory containing test namespaces."
-        :default nil]
-       ["-x" "--extra-test-ns"
-        "Additional test namespace (string) to add (can be repeated)."
-        :default  []
-        :parse-fn (collecting-args-parser)]
-       ["-h" "--help" "Show help." :default false :flag true]))
+           ["-o" "--output" "Output directory." :default "target/coverage"]
+           ["--[no-]text"
+            "Produce a text report." :default false]
+           ["--[no-]html"
+            "Produce an HTML report." :default true]
+           ["--[no-]emma-xml"
+            "Produce an EMMA XML report. [emma.sourceforge.net]" :default false]
+           ["--[no-]lcov"
+            "Produce a lcov/gcov report." :default false]
+           ["--[no-]codecov"
+            "Generate a JSON report for Codecov.io" :default false]
+           ["--[no-]coveralls"
+            "Send a JSON report to Coveralls if on a CI server" :default false]
+           ["--[no-]junit"
+            "Output test results as junit xml file. Supported in :clojure.test runner" :default false]
+           ["--[no-]raw"
+            "Output raw coverage data (for debugging)." :default false]
+           ["--[no-]summary"
+            "Prints a summary" :default true]
+           ["-d" "--[no-]debug"
+            "Output debugging information to stdout." :default false]
+           ["-r" "--runner"
+            "Specify which test runner to use. Currently supported runners are `clojure.test` and `midje`."
+            :default :clojure.test
+            :parse-fn parse-kw-str]
+           ["--[no-]nop" "Instrument with noops." :default false]
+           ["-n" "--ns-regex"
+            "Regex for instrumented namespaces (can be repeated)."
+            :default  []
+            :parse-fn (collecting-args-parser)]
+           ["-e" "--ns-exclude-regex"
+            "Regex for namespaces not to be instrumented (can be repeated)."
+            :default  []
+            :parse-fn (collecting-args-parser)]
+           ["-t" "--test-ns-regex"
+            "Regex for test namespaces (can be repeated)."
+            :default []
+            :parse-fn (collecting-args-parser)]
+           ["-p" "--src-ns-path"
+            "Path (string) to directory containing source code namespaces."
+            :default nil]
+           ["-s" "--test-ns-path"
+            "Path (string) to directory containing test namespaces."
+            :default nil]
+           ["-x" "--extra-test-ns"
+            "Additional test namespace (string) to add (can be repeated)."
+            :default  []
+            :parse-fn (collecting-args-parser)]
+           ["-h" "--help" "Show help." :default false :flag true]))
 
 (defn mark-loaded [namespace]
   (binding [*ns* (find-ns 'clojure.core)]

--- a/cloverage/src/cloverage/coverage.clj
+++ b/cloverage/src/cloverage/coverage.clj
@@ -100,7 +100,7 @@
        ["--[no-]coveralls"
         "Send a JSON report to Coveralls if on a CI server" :default false]
        ["--[no-]junit"
-        "Output test results as junit xml file" :default false]
+        "Output test results as junit xml file. Supported in :clojure.test runner" :default false]
        ["--[no-]raw"
         "Output raw coverage data (for debugging)." :default false]
        ["--[no-]summary"


### PR DESCRIPTION
This PR refactors the `runner-fn` a little to give it access to the parsed cli arguments. That makes it possible to make the junit option behave more like the other report options in that you just have to enable it and it will write to the same output directory as all the other reports.

I think this is basically what @palfrey meant with his comment in #80 

This would resolve #116 