### PR TITLE
Update travis link/badge, remove CircleCI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ cloverage
 
 Simple clojure coverage tool.
 
-Travis: [![Build Status](https://secure.travis-ci.org/lshift/cloverage.png?branch=master)](http://travis-ci.org/lshift/cloverage) CircleCi: [![CircleCI](https://circleci.com/gh/lshift/cloverage.svg?style=svg)](https://circleci.com/gh/lshift/cloverage)
+Travis: [![Build Status](https://secure.travis-ci.org/cloverage/cloverage.png?branch=master)](https://travis-ci.org/cloverage/cloverage)
 
 ## Installation
 


### PR DESCRIPTION
Travis link should be to cloverage/cloverage, not lshift/cloverage. CircleCI appears to not be set up atm.