### PR TITLE
Add cljfmt plugin & travis hook / format sources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,19 @@
 language: clojure
-lein: lein2
-sudo: true
+lein: 2.7.1
+sudo: false
 
-before_install: yes | sudo lein upgrade
 install:
-  - (cd cloverage && lein2 deps)
-  - (cd lein-cloverage && lein2 deps)
+  - (cd cloverage && lein deps)
+  - (cd lein-cloverage && lein deps)
 
 before_script:
   - npm install -g eclint
   - eclint check .* **
-  - (cd cloverage && lein2 cljfmt check)
-  - (cd lein-cloverage && lein2 cljfmt check)
+  - (cd cloverage && lein cljfmt check)
+  - (cd lein-cloverage && lein cljfmt check)
 script:
-  - (cd cloverage && lein2 test)
-  - (cd lein-cloverage && lein2 test)
+  - (cd cloverage && lein test)
+  - (cd lein-cloverage && lein test)
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,24 @@
 language: clojure
 lein: lein2
-install: (cd cloverage && lein2 deps) && (cd lein-cloverage && lein2 deps)
-script: (cd cloverage && lein2 test) && (cd lein-cloverage && lein2 test)
-sudo: false
-cache:
-  directories:
-    - $HOME/.m2
+sudo: true
+
+before_install: yes | sudo lein upgrade
+install:
+  - (cd cloverage && lein2 deps)
+  - (cd lein-cloverage && lein2 deps)
 
 before_script:
   - npm install -g eclint
   - eclint check .* **
+  - (cd cloverage && lein2 cljfmt check)
+  - (cd lein-cloverage && lein2 cljfmt check)
+script:
+  - (cd cloverage && lein2 test)
+  - (cd lein-cloverage && lein2 test)
+
+cache:
+  directories:
+    - $HOME/.m2
 
 jdk:
   - oraclejdk8

--- a/cloverage/project.clj
+++ b/cloverage/project.clj
@@ -27,7 +27,8 @@
                  [slingshot "0.12.2"]
                  [cheshire "5.6.3"]]
   :profiles {:dev    {:aot          ^:replace []
-                      :dependencies [[org.clojure/clojure "1.8.0"]]}
+                      :dependencies [[org.clojure/clojure "1.8.0"]]
+                      :plugins [[lein-cljfmt "0.5.6"]] }
              :1.4    {:dependencies [[org.clojure/clojure "1.4.0"]]}
              :1.5    {:dependencies [[org.clojure/clojure "1.5.1"]]}
              :1.6    {:dependencies [[org.clojure/clojure "1.6.0"]]}

--- a/cloverage/src/cloverage/coverage.clj
+++ b/cloverage/src/cloverage/coverage.clj
@@ -85,53 +85,53 @@
 
 (defn parse-args [args]
   (cli/cli args
-       ["-o" "--output" "Output directory." :default "target/coverage"]
-       ["--[no-]text"
-        "Produce a text report." :default false]
-       ["--[no-]html"
-        "Produce an HTML report." :default true]
-       ["--[no-]emma-xml"
-        "Produce an EMMA XML report. [emma.sourceforge.net]" :default false]
-       ["--[no-]lcov"
-        "Produce a lcov/gcov report." :default false]
-       ["--[no-]codecov"
-        "Generate a JSON report for Codecov.io" :default false]
-       ["--[no-]coveralls"
-        "Send a JSON report to Coveralls if on a CI server" :default false]
-       ["--[no-]raw"
-        "Output raw coverage data (for debugging)." :default false]
-       ["--[no-]summary"
-        "Prints a summary" :default true]
-       ["-d" "--[no-]debug"
-        "Output debugging information to stdout." :default false]
-       ["-r" "--runner"
-        "Specify which test runner to use. Currently supported runners are `clojure.test` and `midje`."
-        :default :clojure.test
-        :parse-fn parse-kw-str]
-       ["--[no-]nop" "Instrument with noops." :default false]
-       ["-n" "--ns-regex"
-        "Regex for instrumented namespaces (can be repeated)."
-        :default  []
-        :parse-fn (collecting-args-parser)]
-       ["-e" "--ns-exclude-regex"
-        "Regex for namespaces not to be instrumented (can be repeated)."
-        :default  []
-        :parse-fn (collecting-args-parser)]
-       ["-t" "--test-ns-regex"
-        "Regex for test namespaces (can be repeated)."
-        :default []
-        :parse-fn (collecting-args-parser)]
-       ["-p" "--src-ns-path"
-        "Path (string) to directory containing source code namespaces."
-        :default nil]
-       ["-s" "--test-ns-path"
-        "Path (string) to directory containing test namespaces."
-        :default nil]
-       ["-x" "--extra-test-ns"
-        "Additional test namespace (string) to add (can be repeated)."
-        :default  []
-        :parse-fn (collecting-args-parser)]
-       ["-h" "--help" "Show help." :default false :flag true]))
+           ["-o" "--output" "Output directory." :default "target/coverage"]
+           ["--[no-]text"
+            "Produce a text report." :default false]
+           ["--[no-]html"
+            "Produce an HTML report." :default true]
+           ["--[no-]emma-xml"
+            "Produce an EMMA XML report. [emma.sourceforge.net]" :default false]
+           ["--[no-]lcov"
+            "Produce a lcov/gcov report." :default false]
+           ["--[no-]codecov"
+            "Generate a JSON report for Codecov.io" :default false]
+           ["--[no-]coveralls"
+            "Send a JSON report to Coveralls if on a CI server" :default false]
+           ["--[no-]raw"
+            "Output raw coverage data (for debugging)." :default false]
+           ["--[no-]summary"
+            "Prints a summary" :default true]
+           ["-d" "--[no-]debug"
+            "Output debugging information to stdout." :default false]
+           ["-r" "--runner"
+            "Specify which test runner to use. Currently supported runners are `clojure.test` and `midje`."
+            :default :clojure.test
+            :parse-fn parse-kw-str]
+           ["--[no-]nop" "Instrument with noops." :default false]
+           ["-n" "--ns-regex"
+            "Regex for instrumented namespaces (can be repeated)."
+            :default  []
+            :parse-fn (collecting-args-parser)]
+           ["-e" "--ns-exclude-regex"
+            "Regex for namespaces not to be instrumented (can be repeated)."
+            :default  []
+            :parse-fn (collecting-args-parser)]
+           ["-t" "--test-ns-regex"
+            "Regex for test namespaces (can be repeated)."
+            :default []
+            :parse-fn (collecting-args-parser)]
+           ["-p" "--src-ns-path"
+            "Path (string) to directory containing source code namespaces."
+            :default nil]
+           ["-s" "--test-ns-path"
+            "Path (string) to directory containing test namespaces."
+            :default nil]
+           ["-x" "--extra-test-ns"
+            "Additional test namespace (string) to add (can be repeated)."
+            :default  []
+            :parse-fn (collecting-args-parser)]
+           ["-h" "--help" "Show help." :default false :flag true]))
 
 (defn mark-loaded [namespace]
   (binding [*ns* (find-ns 'clojure.core)]
@@ -204,10 +204,10 @@
         runner        (runner-fn (:runner opts))
         start         (System/currentTimeMillis)
         namespaces    (set/difference
-                        (into #{}
-                              (concat add-nses
-                                      (find-nses ns-path ns-regexs)))
-                        (into #{} (find-nses ns-path exclude-regex)))
+                       (into #{}
+                             (concat add-nses
+                                     (find-nses ns-path ns-regexs)))
+                       (into #{} (find-nses ns-path exclude-regex)))
         test-nses     (concat add-test-nses (find-nses test-ns-path test-regexs))]
     (if help?
       (println help)
@@ -240,7 +240,7 @@
             (let [stats (rep/gather-stats @*covered*)
                   results [(when text? (rep/text-report output stats))
                            (when html? (rep/html-report output stats)
-                             (rep/html-summary output stats))
+                                 (rep/html-summary output stats))
                            (when emma-xml? (rep/emma-xml-report output stats))
                            (when lcov? (rep/lcov-report output stats))
                            (when raw? (rep/raw-report output stats @*covered*))

--- a/cloverage/src/cloverage/debug.clj
+++ b/cloverage/src/cloverage/debug.clj
@@ -21,6 +21,6 @@
 (defn dump-instrumented [forms name]
   (when *debug*
     (with-open [ou (writer (str "debug-" name))]
-        (binding [*out* ou
-                  *print-meta* true]
-          (doall (map prn forms))))))
+      (binding [*out* ou
+                *print-meta* true]
+        (doall (map prn forms))))))

--- a/cloverage/src/cloverage/kahn.clj
+++ b/cloverage/src/cloverage/kahn.clj
@@ -32,14 +32,14 @@
    algorithm, where g is a map of nodes to sets of nodes. If g is
    cyclic, returns nil."
   ([g]
-     (kahn-sort (normalize g) [] (no-incoming g)))
+   (kahn-sort (normalize g) [] (no-incoming g)))
   ([g l s]
-     (if (empty? s)
-       (when (every? empty? (vals g)) l)
-       (let [[n s'] (take-1 s)
-             m (g n)
-             g' (reduce #(update-in % [n] without %2) g m)]
-         (recur g' (conj l n) (union s' (intersection (no-incoming g') m)))))))
+   (if (empty? s)
+     (when (every? empty? (vals g)) l)
+     (let [[n s'] (take-1 s)
+           m (g n)
+           g' (reduce #(update-in % [n] without %2) g m)]
+       (recur g' (conj l n) (union s' (intersection (no-incoming g') m)))))))
 
 (comment
   (def acyclic-g
@@ -59,5 +59,4 @@
 
   (kahn-sort acyclic-g) ;=> [3 5 7 8 10 11 2 9]
   (kahn-sort cyclic-g) ;=> nil
-
-  )
+)

--- a/cloverage/src/cloverage/report.clj
+++ b/cloverage/src/cloverage/report.clj
@@ -10,13 +10,13 @@
             [cheshire.core :as json]))
 
 (def html-escapes
-  { \space "&nbsp;"
-    \& "&amp;"
-    \< "&lt;"
-    \> "&gt;"
-    \" "&quot;"
-    \' "&#x27;"
-    \/ "&#x2F;"})
+  {\space "&nbsp;"
+   \& "&amp;"
+   \< "&lt;"
+   \> "&gt;"
+   \" "&quot;"
+   \' "&#x27;"
+   \/ "&#x2F;"})
 
 (defn md5 [s]
   (let [algorithm (MessageDigest/getInstance "MD5")
@@ -88,8 +88,7 @@
      :blank-lines   (count (filter :blank? lines))
      :instrd-lines  (count (filter :instrumented? lines))
      :covered-lines (count (filter :covered? lines))
-     :partial-lines (count (filter :partial? lines))
-     }))
+     :partial-lines (count (filter :partial? lines))}))
 
 (defn stats-report [file cov]
   (.mkdirs (.getParentFile file))
@@ -161,15 +160,15 @@
   "Write out lcov report to *out*"
   [forms]
   (doseq [[rel-file file-forms] (group-by :file forms)]
-        (let [lines (line-stats file-forms)
-              instrumented (filter :instrumented? lines)]
-          (println "TN:")
-          (printf "SF:%s%n" rel-file)
-          (doseq [line instrumented]
-            (printf "DA:%d,%d%n" (:line line) (:hit line)))
-          (printf "LF:%d%n" (count instrumented))
-          (printf "LH:%d%n" (count (filter (fn [line] (> (:hit line) 0)) lines)))
-          (println "end_of_record"))))
+    (let [lines (line-stats file-forms)
+          instrumented (filter :instrumented? lines)]
+      (println "TN:")
+      (printf "SF:%s%n" rel-file)
+      (doseq [line instrumented]
+        (printf "DA:%d,%d%n" (:line line) (:hit line)))
+      (printf "LF:%d%n" (count instrumented))
+      (printf "LH:%d%n" (count (filter (fn [line] (> (:hit line) 0)) lines)))
+      (println "end_of_record"))))
 
 (defn lcov-report
   "Write LCOV report to '${out-dir}/lcov.info'."
@@ -178,7 +177,6 @@
     (.mkdirs (.getParentFile file))
     (with-out-writer file (write-lcov-report forms))
     nil))
-
 
 ;; Java 7 has a much nicer API, but this supports Java 6.
 (defn relative-path [target-dir base-dir]
@@ -211,8 +209,7 @@
   (stats-report (File. out-dir "coverage.txt") forms)
   (doseq [[rel-file file-forms] (group-by :file forms)]
     (let [file     (File. out-dir (str rel-file ".html"))
-          rootpath (relative-path (File. out-dir) (.getParentFile file))
-          ]
+          rootpath (relative-path (File. out-dir) (.getParentFile file))]
       (.mkdirs (.getParentFile file))
       (with-out-writer file
         (println "<html>")
@@ -229,26 +226,26 @@
                           (:instrumented? line) "not-covered"
                           :else            "not-tracked")]
             (printf
-               "<span class=\"%s\" title=\"%d out of %d forms covered\">
+             "<span class=\"%s\" title=\"%d out of %d forms covered\">
                  %03d&nbsp;&nbsp;%s
                 </span><br/>%n"
-                cls (:hit line) (:total line)
-                (:line line)
-                (cs/escape (:text line " ") html-escapes))))
+             cls (:hit line) (:total line)
+             (:line line)
+             (cs/escape (:text line " ") html-escapes))))
         (println " </body>")
         (println "</html>")))))
 
 (defn- td-bar [total & parts]
   (str "<td class=\"with-bar\">"
        (apply str
-         (map (fn [[key cnt]]
-                (if (> cnt 0)
-                  (format "<div class=\"%s\"
+              (map (fn [[key cnt]]
+                     (if (> cnt 0)
+                       (format "<div class=\"%s\"
                                 style=\"width:%s%%;
                                         float:left;\"> %d </div>"
-                    (name key) (/ (* 100.0 cnt) total) cnt)
-                  ""))
-              parts))
+                               (name key) (/ (* 100.0 cnt) total) cnt)
+                       ""))
+                   parts))
        "</td>"))
 
 (defn- td-num [content]
@@ -303,17 +300,16 @@
           (println "<tr>")
           (printf  " <td><a href=\"%s.html\">%s</a></td>" filepath libname)
           (println (td-bar forms [:covered cov-forms]
-                                 [:not-covered mis-forms]))
+                           [:not-covered mis-forms]))
           (println (td-num (format "%.2f %%" (/ (* 100.0 cov-forms) forms))))
           (println (td-bar instrd [:covered covered]
-                                  [:partial partial]
-                                  [:not-covered missed]))
+                           [:partial partial]
+                           [:not-covered missed]))
           (println (td-num (format "%.2f %%" (/ (* 100.0 (+ covered partial))
                                                 instrd))))
           (println
-            (apply str (map td-num [lines blank instrd])))
-          (println "</tr>")
-          ))
+           (apply str (map td-num [lines blank instrd])))
+          (println "</tr>")))
       (println "<tr><td>Totals:</td>")
       (println (td-bar nil))
       (println (td-num (format "%.2f %%" (:percent-forms-covered totalled-stats))))
@@ -329,36 +325,35 @@
   (letfn [(has-env [s] (= (System/getenv s) "true"))
           (service-info [sname job-id-var] [sname (System/getenv job-id-var)])]
     (let [[service job-id]
-             (cond
+          (cond
                ;; docs.travis-ci.com/user/ci-environment/
-               (has-env "TRAVIS") (service-info "travis-ci" "TRAVIS_JOB_ID")
+            (has-env "TRAVIS") (service-info "travis-ci" "TRAVIS_JOB_ID")
                ;; circleci.com/docs/environment-variables
-               (has-env "CIRCLECI")
-                 (service-info "circleci" "CIRCLE_BUILD_NUM")
+            (has-env "CIRCLECI")
+            (service-info "circleci" "CIRCLE_BUILD_NUM")
                ;; bit.ly/semaphoreapp-env-vars
-               (has-env "SEMAPHORE") (service-info "semaphore" "REVISION")
+            (has-env "SEMAPHORE") (service-info "semaphore" "REVISION")
                ;; bit.ly/jenkins-env-vars
-               (System/getenv "JENKINS_URL")
-                 (service-info "jenkins" "BUILD_ID")
+            (System/getenv "JENKINS_URL")
+            (service-info "jenkins" "BUILD_ID")
                ;; bit.ly/codeship-env-vars
-               (= (System/getenv "CI_NAME") "codeship")
-                 (service-info "codeship" "CI_BUILD_NUMBER"))
+            (= (System/getenv "CI_NAME") "codeship")
+            (service-info "codeship" "CI_BUILD_NUMBER"))
           covdata (map
-                    (fn [[file file-forms]]
-                      (let [lines (line-stats file-forms)]
-                        {:name file
-                         :source_digest (md5 (cs/join "\n" (map :text lines)))
+                   (fn [[file file-forms]]
+                     (let [lines (line-stats file-forms)]
+                       {:name file
+                        :source_digest (md5 (cs/join "\n" (map :text lines)))
                          ;; >0: covered (number of times hit)
                          ;; 0: not covered
                          ;; null: blank
-                         :coverage (map #(if (:instrumented? %) (:hit %)) lines)}))
-                      (filter (fn [[file _]] file)
-                              (group-by :file forms)))]
-          (with-out-writer (File. out-dir "coveralls.json")
-            (print (json/generate-string {:service_job_id job-id
-                                          :service_name service
-                                          :source_files covdata}))))))
-
+                        :coverage (map #(if (:instrumented? %) (:hit %)) lines)}))
+                   (filter (fn [[file _]] file)
+                           (group-by :file forms)))]
+      (with-out-writer (File. out-dir "coveralls.json")
+        (print (json/generate-string {:service_job_id job-id
+                                      :service_name service
+                                      :source_files covdata}))))))
 
 (defn codecov-report [out-dir forms]
   (println "codecov start")
@@ -389,7 +384,7 @@
   (with-out-writer (File. (File. out-dir) "raw-data.clj")
     (clojure.pprint/pprint (zipmap (range) covered)))
   (with-out-writer (File. (File. out-dir) "raw-stats.clj")
-                   (clojure.pprint/pprint stats)))
+    (clojure.pprint/pprint stats)))
 
 (defn summary
   "Create a text summary for output on the command line"
@@ -412,14 +407,14 @@
         bad-namespaces (filter #(or (not= 100.0 (:forms %)) (not= 100.0 (:lines %))) namespaces)]
 
     (str
-      (when (< 0 (count bad-namespaces))
-        (str
-          (with-out-str (clojure.pprint/print-table [:name :forms_percent :lines_percent] bad-namespaces))
-          "Files with 100% coverage: "
-          (- (count namespaces) (count bad-namespaces))
-          "\n"))
-      "\nForms covered: "
-      (format "%.2f %%" (:percent-forms-covered totalled-stats))
-      "\nLines covered: "
-      (format "%.2f %%" (:percent-lines-covered totalled-stats))
-      "\n")))
+     (when (< 0 (count bad-namespaces))
+       (str
+        (with-out-str (clojure.pprint/print-table [:name :forms_percent :lines_percent] bad-namespaces))
+        "Files with 100% coverage: "
+        (- (count namespaces) (count bad-namespaces))
+        "\n"))
+     "\nForms covered: "
+     (format "%.2f %%" (:percent-forms-covered totalled-stats))
+     "\nLines covered: "
+     (format "%.2f %%" (:percent-lines-covered totalled-stats))
+     "\n")))

--- a/cloverage/src/cloverage/sample.clj
+++ b/cloverage/src/cloverage/sample.clj
@@ -115,16 +115,16 @@
 (defn transaction-fn
   [n]
   (dosync
-    (cond
-      (zero? n) :zero
-      :else     (throw (RuntimeException. "FAIL TRANSACTION")))))
+   (cond
+     (zero? n) :zero
+     :else     (throw (RuntimeException. "FAIL TRANSACTION")))))
 
 (deftest failing-transaction
   (is (thrown? Exception (transaction-fn 1))))
 
 (letfn [(covered [] (+ 2 3))
         (not-covered []
-          {:and :not-tracked})
+                     {:and :not-tracked})
         (not-covered [] ({:preimage :image} :preimage))]
   (covered))
 

--- a/cloverage/test/cloverage/coverage_test.clj
+++ b/cloverage/test/cloverage/coverage_test.clj
@@ -70,7 +70,7 @@
 
 (t/deftest test-wrap-list
   (t/is (expand= `(cov/capture 0 ((cov/capture 1 +) (cov/capture 2 1)
-                                  (cov/capture 3 2)))
+                                                    (cov/capture 3 2)))
                  (inst/wrap #'cov/track-coverage 0 `(+ 1 2)))))
 
 ;; XXX: the order that forms are registered is now from outside in. Bad?
@@ -86,13 +86,13 @@
                  (inst/wrap #'cov/track-coverage 0 '(fn ([a] a) ([a b] b))))
         "Unnamed fn with multiple overloads")
   (t/is (expand= `(cov/capture 5 (~(symbol "fn") ~'foo
-                                  [~'a] (cov/capture 6 ~'a)))
+                                                 [~'a] (cov/capture 6 ~'a)))
                  (inst/wrap #'cov/track-coverage 0
                             '(fn foo [a] a)))
         "Named fn with single overload")
   (t/is (expand= `(cov/capture 7 (~(symbol "fn") ~'foo
-                                  ([~'a] (cov/capture 8 ~'a))
-                                  ([~'a ~'b] (cov/capture 9 ~'b))))
+                                                 ([~'a] (cov/capture 8 ~'a))
+                                                 ([~'a ~'b] (cov/capture 9 ~'b))))
                  (inst/wrap #'cov/track-coverage 0 '(fn foo ([a] a) ([a b] b))))
         "Named fn with multiple overloads"))
 
@@ -112,7 +112,7 @@
                  (inst/wrap #'cov/track-coverage 0 '(let [a 1 b 2]))))
   (t/is (expand= `(cov/capture 6 (~(symbol "let") [~'a (cov/capture 7 1)
                                                    ~'b (cov/capture 8 2)]
-                                  (cov/capture 9 ~'a)))
+                                                  (cov/capture 9 ~'a)))
                  (inst/wrap #'cov/track-coverage 0 '(let [a 1 b 2] a)))))
 
 (t/deftest test-wrap-cond
@@ -189,7 +189,7 @@
     #_(with-out-writer "out/foo"
         (doseq [form-info cov]
           (println form-info)))
-    #_(println "Form is" )
+    #_(println "Form is")
     (t/is found)
     (t/is (:line found))
     (t/is (find-form cov '(inc (m c 0))))))

--- a/cloverage/test/cloverage/dependency_test.clj
+++ b/cloverage/test/cloverage/dependency_test.clj
@@ -2,9 +2,7 @@
   (:require [cloverage.dependency :as cd]
             [clojure.test :as t]))
 
-
-(def ns-fixtures {
-                  ;; sources snipped from incanter : https://github.com/liebke/incanter
+(def ns-fixtures {;; sources snipped from incanter : https://github.com/liebke/incanter
                   :incanter-core
                   {:ns-source
                    '(ns ^{:doc "This is the core numerics library for Incanter.
@@ -19,7 +17,7 @@
               "
                           :author "David Edgar Liebke"}
 
-                        incanter.core
+                     incanter.core
 
                       (:use [incanter internal]
                             [incanter.infix :only (infix-to-prefix defop)]
@@ -49,7 +47,7 @@
                 basic Bayesian modeling and inference.
                 "
                           :author "David Edgar Liebke"}
-                        incanter.bayes
+                     incanter.bayes
                       (:use [incanter.core :only (matrix mmult mult div minus trans ncol nrow
                                                          plus to-list decomp-cholesky solve half-vectorize
                                                          vectorize symmetric-matrix identity-matrix kronecker
@@ -82,7 +80,7 @@
              (t/is (= expected result)
                    (str "Parsing " ns-name
                         " should give " expected
-                        " but got " result ))))))
+                        " but got " result))))))
 
 (t/deftest test-dependency-sort
   (let [dep-lists [['first #{'fourth}]
@@ -91,8 +89,7 @@
                    ['fourth #{'fifth}]
                    ['fifth #{}]]
         result    (cd/dependency-sort dep-lists)
-        index-map (zipmap result (range))
-        ]
+        index-map (zipmap result (range))]
     (t/is (not (nil? result)) "Dependency sort should not be nil.")
     (doseq [[name deps] dep-lists]
       (let [my-index (get index-map name)]

--- a/cloverage/test/cloverage/instrument_test.clj
+++ b/cloverage/test/cloverage/instrument_test.clj
@@ -46,7 +46,7 @@
   (t/is (= :do (form-type- '(do 1 2 3))))
   (t/is (= :list (form-type- '(loop 1 2 3)
                              {'loop 'hoop} ;fake a local binding
-                             ))))
+))))
 
 (t/deftest do-wrap-for-record-returns-record
   (t/is (= 1 (method (eval (inst/wrap #'inst/nop 0 (Record. 1)))))))

--- a/cloverage/test/cloverage/report_test.clj
+++ b/cloverage/test/cloverage/report_test.clj
@@ -41,8 +41,6 @@
 (deftest total-stats-zero
   (is (= {:percent-lines-covered 0.0, :percent-forms-covered 0.0} (total-stats {}))))
 
-
-
 (deftest gather-starts-works-on-empty-forms
   (is (= [] (gather-stats []))))
 

--- a/cloverage/test/cloverage/sample/raw-data.clj
+++ b/cloverage/test/cloverage/sample/raw-data.clj
@@ -2,11 +2,11 @@
  {:form
   (ns
    cloverage.sample.dummy-sample
-   "This namespace is necessary for redundancy.\n  It allows us to check whether regexs in combination with path parameters work."),
+    "This namespace is necessary for redundancy.\n  It allows us to check whether regexs in combination with path parameters work."),
   :full-form
   (ns
    cloverage.sample.dummy-sample
-   "This namespace is necessary for redundancy.\n  It allows us to check whether regexs in combination with path parameters work."),
+    "This namespace is necessary for redundancy.\n  It allows us to check whether regexs in combination with path parameters work."),
   :tracked true,
   :line 1,
   :lib cloverage.sample.dummy-sample,
@@ -16,22 +16,22 @@
  1
  {:form
   (def
-   dummy-function
-   (clojure.core/fn
-    ([& args]
-     (cloverage.instrument/wrapm
-      cloverage.coverage/track-coverage
-      5
-      (println "Hello, World!"))))),
+    dummy-function
+    (clojure.core/fn
+      ([& args]
+       (cloverage.instrument/wrapm
+        cloverage.coverage/track-coverage
+        5
+        (println "Hello, World!"))))),
   :full-form
   (def
-   dummy-function
-   (clojure.core/fn
-    ([& args]
-     (cloverage.instrument/wrapm
-      cloverage.coverage/track-coverage
-      5
-      (println "Hello, World!"))))),
+    dummy-function
+    (clojure.core/fn
+      ([& args]
+       (cloverage.instrument/wrapm
+        cloverage.coverage/track-coverage
+        5
+        (println "Hello, World!"))))),
   :tracked true,
   :line 5,
   :lib cloverage.sample.dummy-sample,

--- a/cloverage/test/cloverage/sample/raw-stats.clj
+++ b/cloverage/test/cloverage/sample/raw-stats.clj
@@ -5,11 +5,11 @@
   :form
   (ns
    cloverage.sample.dummy-sample
-   "This namespace is necessary for redundancy.\n  It allows us to check whether regexs in combination with path parameters work."),
+    "This namespace is necessary for redundancy.\n  It allows us to check whether regexs in combination with path parameters work."),
   :full-form
   (ns
    cloverage.sample.dummy-sample
-   "This namespace is necessary for redundancy.\n  It allows us to check whether regexs in combination with path parameters work."),
+    "This namespace is necessary for redundancy.\n  It allows us to check whether regexs in combination with path parameters work."),
   :tracked true,
   :covered true,
   :hits 1}
@@ -32,22 +32,22 @@
   :file "cloverage/sample/dummy_sample.clj",
   :form
   (def
-   dummy-function
-   (clojure.core/fn
-    ([& args]
-     (cloverage.instrument/wrapm
-      cloverage.coverage/track-coverage
-      5
-      (println "Hello, World!"))))),
+    dummy-function
+    (clojure.core/fn
+      ([& args]
+       (cloverage.instrument/wrapm
+        cloverage.coverage/track-coverage
+        5
+        (println "Hello, World!"))))),
   :full-form
   (def
-   dummy-function
-   (clojure.core/fn
-    ([& args]
-     (cloverage.instrument/wrapm
-      cloverage.coverage/track-coverage
-      5
-      (println "Hello, World!"))))),
+    dummy-function
+    (clojure.core/fn
+      ([& args]
+       (cloverage.instrument/wrapm
+        cloverage.coverage/track-coverage
+        5
+        (println "Hello, World!"))))),
   :tracked true,
   :covered true,
   :hits 1}

--- a/lein-cloverage/project.clj
+++ b/lein-cloverage/project.clj
@@ -18,4 +18,5 @@
   :deploy-repositories [["clojars" {:username :env/clojars_username :password :env/clojars_password :sign-releases false}]]
   :min-lein-version "2.0.0"
   :dependencies [[bultitude "0.2.8"]]
+  :profiles {:dev {:plugins [[lein-cljfmt "0.5.6"]]}}
   :eval-in-leiningen true)

--- a/lein-cloverage/test/leiningen/test_cloverage.clj
+++ b/lein-cloverage/test/leiningen/test_cloverage.clj
@@ -1,2 +1,2 @@
 (ns leiningen.test-cloverage
-    (:require leiningen.cloverage))
+  (:require leiningen.cloverage))


### PR DESCRIPTION
Had problems getting `lein-cljfmt` to play nicely with the travis-supplied lein version; adding `before_install: yes | sudo lein upgrade` to the config seemed to fix it.

Source was bulk formatted with `lein cljfmt fix` in each of the subdirs