### PR TITLE
Move changelog to separate file - fixes #144

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,63 @@
+# Cloverage Changelog
+
+Pull requests are required to update this changelog.  Changelog entries should
+mention and link to any issues or tickets involved in the change, and should
+provide a short summary description of the particular changes of the patch.
+
+Include the issue number (#xxx) which will link back to the originating issue
+in github. Commentary on the change should appear as a nested, unordered list.
+
+## 1.0.8 (WIP)
+- Features
+  - Add [Code of Conduct](https://github.com/cloverage/cloverage/blob/master/CODE_OF_CONDUCT.md) (#128)
+  - Add junit support with the `--junit` flag (#127)
+- Improvements
+  - Coverage within `for` comprehensions is always partial (#23)
+  - Move Changelog to separate file (#144)
+
+## 1.0.7
+- Features
+  - Add codecov.io support with the `--codecov` flag (#78)
+  - Add lcov (e.g. coverlay) support with the `--lcov` flag (#114)
+  - Support for midje as a test runner with `--runner :midje` (#64)
+  - Support for cljc files (#93/#94)
+- Improvements
+  - Coverage fn (internal hot loop) optimization (#90)
+  - Dependency upgrades, including running tests on Oracle JDK 8 (#105)
+- Bugfixes
+  - Fix Unicode (UTF-8) support for HTML output (#100)
+  - Fix handling of multibyte characters (#108)
+  - Fix HTML entity encoding bug (#55)
+  - Coveralls report: fix source digest, line hit numbers (#96)
+
+## 1.0.6
+- Features
+  - Option to exclude namespaces (#57/#73)
+  - Improved records fixes for Compojure (#66/#69)
+  - Option to specify a path to src/test namespaces (#70)
+  - Automatic push out of snapshot releases (#65)
+  - Handle records correctly (#59)
+  - Text summary of results (#50)
+- Bugfixes
+  - Correct test namespaces regex usage (#67)
+  - Cope with zero-namespace situations correctly (#62)
+
+## 1.0.5:
+- Bugfixes:
+ - Work around AOT-ed inline functions not being wrappable (http://dev.clojure.org/jira/browse/CLJ-1330)
+
+## 1.0.4:
+- Features:
+ - Minimal EMMA XML output format support.
+ - [Coveralls](https://coveralls.io) output format.
+ - Cloverage now exits with non-zero exit code when your tests fail
+ - Total % coverage summary in index.html
+- Bugfixes:
+ - Better instrumentation logic is no longer confused by macro/symbol shadowing
+ - Support for (:require [(namespace.prefix (suffix :as rename))]) ns forms
+ - Cloverage jars no longer include all dependencies
+
+## 1.0.3:
+ - fix empty list crash
+ - add letfn support
+ - print html report URL after testing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,9 +37,10 @@ issue.
 
 ### Change Log
 
-Pull requests are required to update the changelog. Changelog entries should
-mention and link to any issues or tickets involved in the change, and should
-provide a short summary description of the particular changes of the patch.
+Pull requests are required to update the [changelog](CHANGELOG.md).
+Changelog entries should mention and link to any issues or tickets
+involved in the change, and should provide a short summary description
+of the particular changes of the patch.
 
 Include the issue number (#xxx) which will link back to the originating issue
 in github. Commentary on the change should appear as a nested, unordered list.

--- a/README.md
+++ b/README.md
@@ -65,60 +65,6 @@ This happens if there is a namespace in your project that requires itself, for e
 
 Remove the self-reference and the test coverage report should report correctly again.
 
-## Changelog
-
-1.0.8 (WIP)
-- Features
-  - Add [Code of Conduct](https://github.com/cloverage/cloverage/blob/master/CODE_OF_CONDUCT.md) (#128)
-  - Add junit support with the `--junit` flag (#127)
-
-1.0.7
-- Features
-  - Add codecov.io support with the `--codecov` flag (#78)
-  - Add lcov (e.g. coverlay) support with the `--lcov` flag (#114)
-  - Support for midje as a test runner with `--runner :midje` (#64)
-  - Support for cljc files (#93/#94)
-- Improvements
-  - Coverage fn (internal hot loop) optimization (#90)
-  - Dependency upgrades, including running tests on Oracle JDK 8 (#105)
-- Bugfixes
-  - Fix Unicode (UTF-8) support for HTML output (#100)
-  - Fix handling of multibyte characters (#108)
-  - Fix HTML entity encoding bug (#55)
-  - Coveralls report: fix source digest, line hit numbers (#96)
-
-1.0.6
-- Features
-  - Option to exclude namespaces (#57/#73)
-  - Improved records fixes for Compojure (#66/#69)
-  - Option to specify a path to src/test namespaces (#70)
-  - Automatic push out of snapshot releases (#65)
-  - Handle records correctly (#59)
-  - Text summary of results (#50)
-- Bugfixes
-  - Correct test namespaces regex usage (#67)
-  - Cope with zero-namespace situations correctly (#62)
-
-1.0.5:
-- Bugfixes:
- - Work around AOT-ed inline functions not being wrappable (http://dev.clojure.org/jira/browse/CLJ-1330)
-
-1.0.4:
-- Features:
- - Minimal EMMA XML output format support.
- - [Coveralls](https://coveralls.io) output format.
- - Cloverage now exits with non-zero exit code when your tests fail
- - Total % coverage summary in index.html
-- Bugfixes:
- - Better instrumentation logic is no longer confused by macro/symbol shadowing
- - Support for (:require [(namespace.prefix (suffix :as rename))]) ns forms
- - Cloverage jars no longer include all dependencies
-
-1.0.3:
- - fix empty list crash
- - add letfn support
- - print html report URL after testing
-
 ## License
 
 Distributed under the Eclipse Public License, the same as Clojure.
@@ -134,3 +80,4 @@ Distributed under the Eclipse Public License, the same as Clojure.
 Some code was taken from
 * Java IO interop (clojure-contrib/duck-streams) by Stuart Sierra (see cloverage/source.clj)
 * Topological sort (https://gist.github.com/1263783) by Alan Dipert (see cloverage/kahn.clj)
+


### PR DESCRIPTION
1. Easier to spot _CHANGELOG.md_ file on project home page rather than having to go looking inside _README.md_.
2. Frequent changelog commits wont clog up history of readme changes