### PR TITLE
Pass-through help option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ in github. Commentary on the change should appear as a nested, unordered list.
 - Improvements
   - Coverage within `for` comprehensions is always partial (#23)
   - Move Changelog to separate file (#144)
+- Bugfixes
+  - Passthrough _-h_ / _--help_ flag to properly show help options (#156)
 
 ## 1.0.7
 - Features

--- a/lein-cloverage/src/leiningen/cloverage.clj
+++ b/lein-cloverage/src/leiningen/cloverage.clj
@@ -8,7 +8,7 @@
 (defn get-lib-version []
   (or (System/getenv "CLOVERAGE_VERSION") "RELEASE"))
 
-(defn cloverage
+(defn ^:pass-through-help cloverage
   "Run code coverage on the project.
 
   To specify cloverage version, set the CLOVERAGE_VERSION environment variable.


### PR DESCRIPTION
Running `lein cloverage --help` produces the following output:

```
$ lein cloverage --help
Run code coverage on the project.

  To specify cloverage version, set the CLOVERAGE_VERSION environment variable.
  Specify -o OUTPUTDIR for output directory, for other options see cloverage.

Arguments: ([& args])
```

I wonder whether it would be more useful to pass-through the `-h` flag so that it prints out the [opts](https://github.com/cloverage/cloverage/blob/master/cloverage/src/cloverage/coverage.clj#L89-L137) that are actaully used?

This patch addresses that, so that `lein cloverage --help` would print:

```
$ lein cloverage --help
 Switches                     Default          Desc                                                                                          
 --------                     -------          ----                                                                                          
 -o, --output                 target/coverage  Output directory.                                                                             
 --no-text, --text            false            Produce a text report.                                                                        
 --no-html, --html            true             Produce an HTML report.                                                                       
 --no-emma-xml, --emma-xml    false            Produce an EMMA XML report. [emma.sourceforge.net]                                            
 --no-lcov, --lcov            false            Produce a lcov/gcov report.                                                                   
 --no-codecov, --codecov      false            Generate a JSON report for Codecov.io                                                         
 --no-coveralls, --coveralls  false            Send a JSON report to Coveralls if on a CI server                                             
 --no-raw, --raw              false            Output raw coverage data (for debugging).                                                     
 --no-summary, --summary      true             Prints a summary                                                                              
 -d, --no-debug, --debug      false            Output debugging information to stdout.                                                       
 -r, --runner                 :clojure.test    Specify which test runner to use. Currently supported runners are `clojure.test` and `midje`. 
 --no-nop, --nop              false            Instrument with noops.                                                                        
 -n, --ns-regex               []               Regex for instrumented namespaces (can be repeated).                                          
 -e, --ns-exclude-regex       []               Regex for namespaces not to be instrumented (can be repeated).                                
 -t, --test-ns-regex          []               Regex for test namespaces (can be repeated).                                                  
 -p, --src-ns-path                             Path (string) to directory containing source code namespaces.                                 
 -s, --test-ns-path                            Path (string) to directory containing test namespaces.                                        
 -x, --extra-test-ns          []               Additional test namespace (string) to add (can be repeated).                                  
 -h, --no-help, --help        false            Show help.  
``` 

**NOTE:** Requesting the leiningen task help will still print the high-level help text:

```
$ lein help cloverage
Run code coverage on the project.

  To specify cloverage version, set the CLOVERAGE_VERSION environment variable.
  Specify -o OUTPUTDIR for output directory, for other options see cloverage.

Arguments: ([& args])
```