### PR TITLE
Split out reporting into separate namespaces

### DIFF
--- a/cloverage/project.clj
+++ b/cloverage/project.clj
@@ -20,13 +20,14 @@
                  [org.clojure/tools.cli "0.3.5"]
                  [org.clojure/tools.logging "0.3.1"]
                  [org.clojure/data.xml "0.0.8"]
+                 [org.clojure/data.json "0.2.6"]
                  [bultitude "0.2.8"]
                  [riddley "0.1.12"]
-                 [slingshot "0.12.2"]
-                 [cheshire "5.6.3"]]
+                 [slingshot "0.12.2"]]
   :profiles {:dev    {:aot          ^:replace []
                       :dependencies [[org.clojure/clojure "1.8.0"]]
-                      :plugins [[lein-cljfmt "0.5.6"]]}
+                      :plugins [[lein-cljfmt "0.5.6"]]
+                      :global-vars {*warn-on-reflection* true}}
              :1.4    {:dependencies [[org.clojure/clojure "1.4.0"]]}
              :1.5    {:dependencies [[org.clojure/clojure "1.5.1"]]}
              :1.6    {:dependencies [[org.clojure/clojure "1.6.0"]]}

--- a/cloverage/src/cloverage/report.clj
+++ b/cloverage/src/cloverage/report.clj
@@ -1,38 +1,16 @@
 (ns cloverage.report
   (:import
-   [java.io File]
-   [java.security MessageDigest]
-   [java.math BigInteger])
+   [java.io File])
   (:require
-   [clojure.java.io :refer [writer reader copy]]
-   [cloverage.source :refer [resource-reader]]
-   [clojure.string :as cs]
-   [clojure.data.xml :as xml]
-   [cheshire.core :as json]))
-
-(def html-escapes
-  {\space "&nbsp;"
-   \& "&amp;"
-   \< "&lt;"
-   \> "&gt;"
-   \" "&quot;"
-   \' "&#x27;"
-   \/ "&#x2F;"})
-
-(defn md5 [^String s]
-  (let [algorithm (MessageDigest/getInstance "MD5")
-        size (* 2 (.getDigestLength algorithm))
-        raw (.digest algorithm (.getBytes s))
-        sig (.toString (BigInteger. 1 raw) 16)
-        padding (apply str (repeat (- size (count sig)) "0"))]
-    (str padding sig)))
+   [clojure.java.io :as io]
+   [cloverage.source :refer [resource-reader]]))
 
 ;; borrowed from duck-streams
 (defmacro with-out-writer
   "Opens a writer on f, binds it to *out*, and evalutes body.
   Anything printed within body will be written to f."
   [^File f & body]
-  `(with-open [stream# (writer ~f)]
+  `(with-open [stream# (io/writer ~f)]
      (binding [*out* stream#]
        ~@body)))
 
@@ -43,14 +21,14 @@
   (into (sorted-map) (group-by :file forms)))
 
 (defn- postprocess-file [lib file forms]
-  (with-open [in (reader (resource-reader file))]
+  (with-open [in (io/reader (resource-reader file))]
     (let [forms-by-line (group-by-line forms)
           make-rec (fn [line text]
                      (map (partial merge {:text text :line line
                                           :lib  lib  :file file})
                           (forms-by-line line [{:line line}])))
-          line-nums (next (iterate inc 0))
-          lines (into [] (line-seq in))]
+          line-nums (iterate inc 1)
+          lines (vec (line-seq in))]
       (mapcat make-rec line-nums lines))))
 
 (defn gather-stats [forms]
@@ -73,14 +51,14 @@
        :times-hit times-hit
        :blank?   (empty? (:text (first line-forms)))
        :covered? (and (> total 0) (= total hit))
-       :partial? (and (> hit 0) (< hit total))
+       :partial? (< 0 hit total)
        :instrumented? (> total 0)})))
 
 (defn file-stats [forms]
   (for [[file file-forms] (group-by :file forms)
         :let [lines (line-stats file-forms)]]
-    {:file file
-     :lib  (:lib  (first file-forms))
+    {:file          file
+     :lib           (:lib  (first file-forms))
 
      :forms         (count (filter :tracked file-forms))
      :covered-forms (count (filter :covered file-forms))
@@ -90,166 +68,6 @@
      :instrd-lines  (count (filter :instrumented? lines))
      :covered-lines (count (filter :covered? lines))
      :partial-lines (count (filter :partial? lines))}))
-
-(defn stats-report [^File file cov]
-  (.mkdirs (.getParentFile file))
-  (with-out-writer file
-    (printf "Lines Non-Blank Instrumented Covered Partial%n")
-    (doseq [file-info (file-stats cov)]
-      (printf "%5d %9d %7d %10d %10d %s%n"
-              (:lines file-info)
-              (- (:lines file-info) (:blank-lines file-info))
-              (:instrd-lines  file-info)
-              (:covered-lines file-info)
-              (:partial-lines file-info)
-              (:file          file-info)))))
-
-(defn text-report [^String out-dir forms]
-  (stats-report (File. out-dir "coverage.txt") forms)
-  (doseq [[^String file file-forms] (group-by :file forms)
-          :when file]
-    (let [file (File. out-dir file)]
-      (.mkdirs (.getParentFile file))
-      (with-out-writer file
-        (doseq [line (line-stats file-forms)]
-          (let [prefix (cond (:blank?   line) " "
-                             (:covered? line) "✔"
-                             (:partial? line) "~"
-                             (:instrumented? line) "✘"
-                             :else           "?")]
-            (println prefix (:text line))))))))
-
-(defn- cov [t left right]
-  (let [percent (if (> right 0) (float (* 100 (/ left right))) 0.0)]
-    [:coverage {:type t :value (format "%.0f%% (%d/%d)" percent left right)}]))
-
-(defn- do-counters [stats]
-  {:lib            ((first stats) :lib)
-   :form-count     (reduce + (map :forms stats))
-   :cov-form-count (reduce + (map :covered-forms stats))
-   :line-count     (reduce + (map :instrd-lines stats))
-   :cov-line-count (reduce + (map :covered-lines stats))})
-
-(defn- counters->cov [tag name cntrs]
-  [tag {:name name}
-   (cov "class, %" 0 1) (cov "method, %" 0 1)
-   (cov "block, %" (cntrs :cov-form-count) (cntrs :form-count))
-   (cov "line, %"  (cntrs :cov-line-count) (cntrs :line-count))])
-
-(defn emma-xml-report
-  "Create '${out-dir}/coverage.xml' in EMMA format (emma.sourceforge.net)."
-  [^String out-dir forms]
-  (let [output-file (File. out-dir "coverage.xml")
-        stats      (doall (file-stats forms))
-        file-count (count (distinct (map :file stats)))
-        lib-count  (count (distinct (map :lib stats)))
-        total      (do-counters stats)
-        by-pkg     (map do-counters (vals (group-by :lib stats)))]
-    (.mkdirs (.getParentFile output-file))
-    (with-open [wr (writer output-file)]
-      (-> [:report
-           [:stats (map #(vector %1 {:value %2})
-                        [:packages :methods :srcfiles :srclines]
-                        [lib-count (total :form-count) file-count (total :line-count)])]
-           [:data (apply conj (counters->cov :all "total" total)
-                         (map #(counters->cov :package (% :lib) %) by-pkg))]]
-          xml/sexp-as-element (xml/emit wr)))
-    nil))
-
-(defn- write-lcov-report
-  "Write out lcov report to *out*"
-  [forms]
-  (doseq [[rel-file file-forms] (group-by :file forms)]
-    (let [lines (line-stats file-forms)
-          instrumented (filter :instrumented? lines)]
-      (println "TN:")
-      (printf "SF:%s%n" rel-file)
-      (doseq [line instrumented]
-        (printf "DA:%d,%d%n" (:line line) (:hit line)))
-      (printf "LF:%d%n" (count instrumented))
-      (printf "LH:%d%n" (count (filter (fn [line] (> (:hit line) 0)) lines)))
-      (println "end_of_record"))))
-
-(defn lcov-report
-  "Write LCOV report to '${out-dir}/lcov.info'."
-  [^String out-dir forms]
-  (let [file (File. out-dir "lcov.info")]
-    (.mkdirs (.getParentFile file))
-    (with-out-writer file (write-lcov-report forms))
-    nil))
-
-;; Java 7 has a much nicer API, but this supports Java 6.
-(defn relative-path [^File target-dir ^File base-dir]
-  ^{:doc "Return the path to target-dir relative to base-dir.
-          Both arguments are java.io.File"}
-  (loop [target-file (.getAbsoluteFile target-dir)
-         base-file   (.getAbsoluteFile base-dir)
-         postpend    ""
-         prepend     ""]
-    (let [target-path (.getAbsolutePath target-file)
-          base-path   (.getAbsolutePath base-file)]
-      (cond
-        (= base-path target-path)
-        (apply str prepend postpend)
-
-        (> (count base-path)
-           (count target-path))
-        (recur target-file (.getParentFile base-file) postpend (str prepend "../"))
-
-        :else
-        (let [new-target (.getParentFile target-file)
-              suffix     (subs target-path
-                               (count (.getAbsolutePath new-target)))]
-          (recur new-target base-file
-                 (str (subs suffix 1) "/" postpend)
-                 prepend))))))
-
-(defn html-report [^String out-dir forms]
-  (copy (resource-reader "coverage.css") (File. out-dir "coverage.css"))
-  (stats-report (File. out-dir "coverage.txt") forms)
-  (doseq [[rel-file file-forms] (group-by :file forms)]
-    (let [file     (File. out-dir (str rel-file ".html"))
-          rootpath (relative-path (File. out-dir) (.getParentFile file))]
-      (.mkdirs (.getParentFile file))
-      (with-out-writer file
-        (println "<html>")
-        (println " <head>")
-        (println "   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">")
-        (printf "  <link rel=\"stylesheet\" href=\"%scoverage.css\"/>" rootpath)
-        (println "  <title>" rel-file "</title>")
-        (println " </head>")
-        (println " <body>")
-        (doseq [line (line-stats file-forms)]
-          (let [cls (cond (:blank?        line) "blank"
-                          (:covered?      line) "covered"
-                          (:partial?      line) "partial"
-                          (:instrumented? line) "not-covered"
-                          :else            "not-tracked")]
-            (printf
-             "<span class=\"%s\" title=\"%d out of %d forms covered\">
-                 %03d&nbsp;&nbsp;%s
-                </span><br/>%n"
-             cls (:hit line) (:total line)
-             (:line line)
-             (cs/escape (:text line " ") html-escapes))))
-        (println " </body>")
-        (println "</html>")))))
-
-(defn- td-bar [total & parts]
-  (str "<td class=\"with-bar\">"
-       (apply str
-              (map (fn [[key cnt]]
-                     (if (> cnt 0)
-                       (format "<div class=\"%s\"
-                                style=\"width:%s%%;
-                                        float:left;\"> %d </div>"
-                               (name key) (/ (* 100.0 cnt) total) cnt)
-                       ""))
-                   parts))
-       "</td>"))
-
-(defn- td-num [content]
-  (format "<td class=\"with-number\">%s</td>" content))
 
 (defn total-stats [forms]
   (let [all-file-stats (file-stats forms)
@@ -261,128 +79,4 @@
         forms      (total :forms)]
     {:percent-lines-covered (if (= lines 0) 0. (* (/ (+ covered partial) lines) 100.0))
      :percent-forms-covered (if (= forms 0) 0. (* (/ cov-forms forms) 100.0))}))
-
-(defn html-summary [^String out-dir forms]
-  (let [index (File. out-dir "index.html")
-        totalled-stats (total-stats forms)]
-    (.mkdirs (File. out-dir))
-    (with-out-writer index
-      (println "<html>")
-      (println " <head>")
-      (println "   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">")
-      (println "  <link rel=\"stylesheet\" href=\"./coverage.css\"/>")
-      (println "  <title>Coverage Summary</title>")
-      (println " </head>")
-      (println " <body>")
-      (println "  <table>")
-      (println "   <thead><tr>")
-      (println "    <td class=\"ns-name\"> Namespace </td>")
-      (println "    <td class=\"with-bar\"> Forms </td>")
-      (println (td-num "Forms %"))
-      (println "    <td class=\"with-bar\"> Lines </td>")
-      (println (td-num "Lines %"))
-      (println (apply str (map td-num ["Total" "Blank" "Instrumented"])))
-      (println "   </tr></thead>")
-      (doseq [file-stat (sort-by :lib (file-stats forms))]
-        (let [filepath  (:file file-stat)
-              libname   (:lib  file-stat)
-
-              forms     (:forms file-stat)
-              cov-forms (:covered-forms file-stat)
-              mis-forms (- forms cov-forms)
-
-              lines     (:lines file-stat)
-              instrd    (:instrd-lines  file-stat)
-              covered   (:covered-lines file-stat)
-              partial   (:partial-lines file-stat)
-              blank     (:blank-lines   file-stat)
-              missed    (- instrd partial covered)]
-          (println "<tr>")
-          (printf  " <td><a href=\"%s.html\">%s</a></td>" filepath libname)
-          (println (td-bar forms [:covered cov-forms]
-                           [:not-covered mis-forms]))
-          (println (td-num (format "%.2f %%" (/ (* 100.0 cov-forms) forms))))
-          (println (td-bar instrd [:covered covered]
-                           [:partial partial]
-                           [:not-covered missed]))
-          (println (td-num (format "%.2f %%" (/ (* 100.0 (+ covered partial))
-                                                instrd))))
-          (println
-           (apply str (map td-num [lines blank instrd])))
-          (println "</tr>")))
-      (println "<tr><td>Totals:</td>")
-      (println (td-bar nil))
-      (println (td-num (format "%.2f %%" (:percent-forms-covered totalled-stats))))
-      (println (td-bar nil))
-      (println (td-num (format "%.2f %%" (:percent-lines-covered totalled-stats))))
-      (println "   </tr>")
-      (println "  </table>")
-      (println " </body>")
-      (println "</html>"))
-    (format "HTML: file://%s" (.getAbsolutePath index))))
-
-(defn coveralls-report [^String out-dir forms]
-  (letfn [(has-env [s] (= (System/getenv s) "true"))
-          (service-info [sname job-id-var] [sname (System/getenv job-id-var)])]
-    (let [[service job-id]
-          (cond
-               ;; docs.travis-ci.com/user/ci-environment/
-            (has-env "TRAVIS") (service-info "travis-ci" "TRAVIS_JOB_ID")
-               ;; circleci.com/docs/environment-variables
-            (has-env "CIRCLECI")
-            (service-info "circleci" "CIRCLE_BUILD_NUM")
-               ;; bit.ly/semaphoreapp-env-vars
-            (has-env "SEMAPHORE") (service-info "semaphore" "REVISION")
-               ;; bit.ly/jenkins-env-vars
-            (System/getenv "JENKINS_URL")
-            (service-info "jenkins" "BUILD_ID")
-               ;; bit.ly/codeship-env-vars
-            (= (System/getenv "CI_NAME") "codeship")
-            (service-info "codeship" "CI_BUILD_NUMBER"))
-          covdata (map
-                   (fn [[file file-forms]]
-                     (let [lines (line-stats file-forms)]
-                       {:name file
-                        :source_digest (md5 (cs/join "\n" (map :text lines)))
-                         ;; >0: covered (number of times hit)
-                         ;; 0: not covered
-                         ;; null: blank
-                        :coverage (map #(if (:instrumented? %) (:hit %)) lines)}))
-                   (filter (fn [[file _]] file)
-                           (group-by :file forms)))]
-      (with-out-writer (File. out-dir "coveralls.json")
-        (print (json/generate-string {:service_job_id job-id
-                                      :service_name service
-                                      :source_files covdata}))))))
-
-(defn codecov-report [^String out-dir forms]
-  (println "codecov start")
-  (let [data (filter (fn [[file _]] file) (group-by :file forms))
-        covdata
-        (into {}
-              (map
-               (fn [[file file-forms]]
-                 ;; https://codecov.io/api#post-json-report
-                 ;; > 0: covered (number of times hit)
-                 ;; true: partially covered
-                 ;; 0: not covered
-                 ;; null: skipped/ignored/empty
-                 ;; the first item in the list must be a null
-                 (vector file
-                         (cons nil
-                               (mapv (fn [line]
-                                       (cond (:blank?   line) nil
-                                             (:covered? line) (:times-hit line)
-                                             (:partial? line) true
-                                             (:instrumented? line) 0
-                                             :else nil)) (line-stats file-forms)))))
-               data))]
-    (with-out-writer (File. out-dir "codecov.json")
-      (print (json/generate-string {:coverage covdata})))))
-
-(defn raw-report [^String out-dir stats covered]
-  (with-out-writer (File. out-dir "raw-data.clj")
-    (clojure.pprint/pprint (zipmap (range) covered)))
-  (with-out-writer (File. out-dir "raw-stats.clj")
-    (clojure.pprint/pprint stats)))
 

--- a/cloverage/src/cloverage/report/codecov.clj
+++ b/cloverage/src/cloverage/report/codecov.clj
@@ -1,0 +1,35 @@
+(ns cloverage.report.codecov
+  (:require
+   [clojure.java.io :as io]
+   [clojure.data.json :as json]
+   [cloverage.report :refer [line-stats with-out-writer]]))
+
+(defn- file-coverage [[file file-forms]]
+  ;; https://codecov.io/api#post-json-report
+  ;; > 0: covered (number of times hit)
+  ;; true: partially covered
+  ;; 0: not covered
+  ;; null: skipped/ignored/empty
+  ;; the first item in the list must be a null
+  (vector file
+          (cons nil
+                (mapv (fn [line]
+                        (cond (:blank?   line) nil
+                              (:covered? line) (:times-hit line)
+                              (:partial? line) true
+                              (:instrumented? line) 0
+                              :else nil)) (line-stats file-forms)))))
+
+(defn report [^String out-dir forms]
+  (let [output-file (io/file out-dir "codecov.json")
+        covdata (->>
+                 forms
+                 (group-by :file)
+                 (filter first)
+                 (map file-coverage)
+                 (into {}))]
+
+    (println "Writing codecov.io report to:" (.getAbsolutePath output-file))
+    (with-out-writer output-file
+      (json/pprint {:coverage covdata} :escape-slash false))))
+

--- a/cloverage/src/cloverage/report/console.clj
+++ b/cloverage/src/cloverage/report/console.clj
@@ -100,6 +100,4 @@
         totals [(colorizer (min all-forms-pct all-lines-pct) "ALL FILES")
                 (colorizer all-forms-pct)
                 (colorizer all-lines-pct)]]
-    (str
-     (with-out-str
-       (print-table ["Namespace" "% Forms" "% Lines"] namespaces totals)))))
+    (print-table ["Namespace" "% Forms" "% Lines"] namespaces totals)))

--- a/cloverage/src/cloverage/report/coveralls.clj
+++ b/cloverage/src/cloverage/report/coveralls.clj
@@ -1,0 +1,68 @@
+(ns cloverage.report.coveralls
+  (:require
+   [clojure.string :as s]
+   [clojure.java.io :as io]
+   [clojure.data.json :as json]
+   [cloverage.report :refer [line-stats with-out-writer]])
+  (:import
+   [java.security MessageDigest]))
+
+(defn md5 [^String s]
+  (let [algorithm (MessageDigest/getInstance "MD5")
+        size (* 2 (.getDigestLength algorithm))
+        raw (.digest algorithm (.getBytes s))
+        sig (.toString (BigInteger. 1 raw) 16)
+        padding (apply str (repeat (- size (count sig)) "0"))]
+    (str padding sig)))
+
+(defn- env?
+  ([s] (env? s "true"))
+  ([s value] (= (System/getenv s) value)))
+
+(defn- service-info [sname job-id-var]
+  [sname (System/getenv job-id-var)])
+
+(defn- file-coverage [[file file-forms]]
+  (let [lines (line-stats file-forms)]
+    {:name file
+     :source_digest (md5 (s/join "\n" (map :text lines)))
+     :coverage (map #(if (:instrumented? %) (:hit %)) lines)}))
+
+(defn report [^String out-dir forms]
+  (let [output-file (io/file out-dir "coveralls.json")
+        [service job-id]
+        (cond
+          ;; docs.travis-ci.com/user/ci-environment/
+          (env? "TRAVIS")
+          (service-info "travis-ci" "TRAVIS_JOB_ID")
+
+          ;; circleci.com/docs/environment-variables
+          (env? "CIRCLECI")
+          (service-info "circleci" "CIRCLE_BUILD_NUM")
+
+          ;; bit.ly/semaphoreapp-env-vars
+          (env? "SEMAPHORE")
+          (service-info "semaphore" "REVISION")
+
+          ;; bit.ly/jenkins-env-vars
+          (System/getenv "JENKINS_URL")
+          (service-info "jenkins" "BUILD_ID")
+
+          ;; bit.ly/codeship-env-vars
+          (= (System/getenv "CI_NAME") "codeship")
+          (service-info "codeship" "CI_BUILD_NUMBER"))
+
+        covdata (->>
+                 forms
+                 (group-by :file)
+                 (filter first)
+                 (map file-coverage))]
+
+    (println "Writing coveralls.io report to:" (.getAbsolutePath output-file))
+    (.mkdirs (.getParentFile output-file))
+    (with-out-writer output-file
+      (json/pprint {:service_job_id job-id
+                    :service_name service
+                    :source_files covdata}
+                   :escape-slash false))))
+

--- a/cloverage/src/cloverage/report/emma_xml.clj
+++ b/cloverage/src/cloverage/report/emma_xml.clj
@@ -1,0 +1,44 @@
+(ns cloverage.report.emma-xml
+  (:require
+   [clojure.java.io :as io]
+   [clojure.data.xml :as xml]
+   [cloverage.report :refer [file-stats]]))
+
+(defn- cov [t left right]
+  (let [percent (if (> right 0) (float (* 100 (/ left right))) 0.0)]
+    [:coverage {:type t :value (format "%.0f%% (%d/%d)" percent left right)}]))
+
+(defn- do-counters [stats]
+  {:lib            ((first stats) :lib)
+   :form-count     (reduce + (map :forms stats))
+   :cov-form-count (reduce + (map :covered-forms stats))
+   :line-count     (reduce + (map :instrd-lines stats))
+   :cov-line-count (reduce + (map :covered-lines stats))})
+
+(defn- counters->cov [tag name cntrs]
+  [tag {:name name}
+   (cov "class, %" 0 1) (cov "method, %" 0 1)
+   (cov "block, %" (cntrs :cov-form-count) (cntrs :form-count))
+   (cov "line, %"  (cntrs :cov-line-count) (cntrs :line-count))])
+
+(defn report
+  "Create '${out-dir}/coverage.xml' in EMMA format (emma.sourceforge.net)."
+  [^String out-dir forms]
+  (let [output-file (io/file out-dir "coverage.xml")
+        stats      (doall (file-stats forms))
+        file-count (count (distinct (map :file stats)))
+        lib-count  (count (distinct (map :lib stats)))
+        total      (do-counters stats)
+        by-pkg     (map do-counters (vals (group-by :lib stats)))]
+
+    (println "Writing EMMA report to:" (.getAbsolutePath output-file))
+    (with-open [wr (io/writer output-file)]
+      (-> [:report
+           [:stats (map #(vector %1 {:value %2})
+                        [:packages :methods :srcfiles :srclines]
+                        [lib-count (total :form-count) file-count (total :line-count)])]
+           [:data (apply conj (counters->cov :all "total" total)
+                         (map #(counters->cov :package (% :lib) %) by-pkg))]]
+          xml/sexp-as-element
+          (xml/emit wr)))))
+

--- a/cloverage/src/cloverage/report/html.clj
+++ b/cloverage/src/cloverage/report/html.clj
@@ -1,0 +1,148 @@
+(ns cloverage.report.html
+  (:require
+   [clojure.string :as cs]
+   [clojure.java.io :as io]
+   [cloverage.source :refer [resource-reader]]
+   [cloverage.report :refer [line-stats total-stats file-stats with-out-writer]])
+  (:import
+   [java.io File]))
+
+(def html-escapes
+  {\space "&nbsp;"
+   \& "&amp;"
+   \< "&lt;"
+   \> "&gt;"
+   \" "&quot;"
+   \' "&#x27;"
+   \/ "&#x2F;"})
+
+;; Java 7 has a much nicer API, but this supports Java 6.
+(defn relative-path [^File target-dir ^File base-dir]
+  ^{:doc "Return the path to target-dir relative to base-dir.
+          Both arguments are java.io.File"}
+  (loop [target-file (.getAbsoluteFile target-dir)
+         base-file   (.getAbsoluteFile base-dir)
+         postpend    ""
+         prepend     ""]
+    (let [target-path (.getAbsolutePath target-file)
+          base-path   (.getAbsolutePath base-file)]
+      (cond
+        (= base-path target-path)
+        (apply str prepend postpend)
+
+        (> (count base-path)
+           (count target-path))
+        (recur target-file (.getParentFile base-file) postpend (str prepend "../"))
+
+        :else
+        (let [new-target (.getParentFile target-file)
+              suffix     (subs target-path
+                               (count (.getAbsolutePath new-target)))]
+          (recur new-target base-file
+                 (str (subs suffix 1) "/" postpend)
+                 prepend))))))
+
+(defn- td-bar [total & parts]
+  (str "<td class=\"with-bar\">"
+       (apply str
+              (map (fn [[key cnt]]
+                     (if (> cnt 0)
+                       (format "<div class=\"%s\"
+                                style=\"width:%s%%;
+                                        float:left;\"> %d </div>"
+                               (name key) (/ (* 100.0 cnt) total) cnt)
+                       ""))
+                   parts))
+       "</td>"))
+
+(defn- td-num [content]
+  (format "<td class=\"with-number\">%s</td>" content))
+
+(defn summary [^String out-dir forms]
+  (let [output-file (io/file out-dir "index.html")
+        totalled-stats (total-stats forms)]
+    (println "Writing HTML report to:" (.getAbsolutePath output-file))
+    (with-out-writer output-file
+      (println "<html>")
+      (println " <head>")
+      (println "   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">")
+      (println "  <link rel=\"stylesheet\" href=\"./coverage.css\"/>")
+      (println "  <title>Coverage Summary</title>")
+      (println " </head>")
+      (println " <body>")
+      (println "  <table>")
+      (println "   <thead><tr>")
+      (println "    <td class=\"ns-name\"> Namespace </td>")
+      (println "    <td class=\"with-bar\"> Forms </td>")
+      (println (td-num "Forms %"))
+      (println "    <td class=\"with-bar\"> Lines </td>")
+      (println (td-num "Lines %"))
+      (println (apply str (map td-num ["Total" "Blank" "Instrumented"])))
+      (println "   </tr></thead>")
+      (doseq [file-stat (sort-by :lib (file-stats forms))]
+        (let [filepath  (:file file-stat)
+              libname   (:lib  file-stat)
+
+              forms     (:forms file-stat)
+              cov-forms (:covered-forms file-stat)
+              mis-forms (- forms cov-forms)
+
+              lines     (:lines file-stat)
+              instrd    (:instrd-lines  file-stat)
+              covered   (:covered-lines file-stat)
+              partial   (:partial-lines file-stat)
+              blank     (:blank-lines   file-stat)
+              missed    (- instrd partial covered)]
+          (println "<tr>")
+          (printf  " <td><a href=\"%s.html\">%s</a></td>" filepath libname)
+          (println (td-bar forms [:covered cov-forms]
+                           [:not-covered mis-forms]))
+          (println (td-num (format "%.2f %%" (/ (* 100.0 cov-forms) forms))))
+          (println (td-bar instrd [:covered covered]
+                           [:partial partial]
+                           [:not-covered missed]))
+          (println (td-num (format "%.2f %%" (/ (* 100.0 (+ covered partial))
+                                                instrd))))
+          (println
+           (apply str (map td-num [lines blank instrd])))
+          (println "</tr>")))
+      (println "<tr><td>Totals:</td>")
+      (println (td-bar nil))
+      (println (td-num (format "%.2f %%" (:percent-forms-covered totalled-stats))))
+      (println (td-bar nil))
+      (println (td-num (format "%.2f %%" (:percent-lines-covered totalled-stats))))
+      (println "   </tr>")
+      (println "  </table>")
+      (println " </body>")
+      (println "</html>"))))
+
+(defn report [^String out-dir forms]
+  (io/copy (resource-reader "coverage.css") (io/file out-dir "coverage.css"))
+  (summary out-dir forms)
+  (doseq [[rel-file file-forms] (group-by :file forms)]
+    (let [file     (io/file out-dir (str rel-file ".html"))
+          rootpath (relative-path (io/file out-dir) (.getParentFile file))]
+      (with-out-writer file
+        (println "<html>")
+        (println " <head>")
+        (println "   <meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\">")
+        (printf "  <link rel=\"stylesheet\" href=\"%scoverage.css\"/>" rootpath)
+        (println "  <title>" rel-file "</title>")
+        (println " </head>")
+        (println " <body>")
+        (doseq [line (line-stats file-forms)]
+          (let [cls (cond (:blank?        line) "blank"
+                          (:covered?      line) "covered"
+                          (:partial?      line) "partial"
+                          (:instrumented? line) "not-covered"
+                          :else            "not-tracked")]
+            (printf
+             "<span class=\"%s\" title=\"%d out of %d forms covered\">
+                 %03d&nbsp;&nbsp;%s
+                </span><br/>%n"
+             cls (:hit line) (:total line)
+             (:line line)
+             (cs/escape (:text line " ") html-escapes))))
+        (println " </body>")
+        (println "</html>")))))
+

--- a/cloverage/src/cloverage/report/lcov.clj
+++ b/cloverage/src/cloverage/report/lcov.clj
@@ -1,0 +1,26 @@
+(ns cloverage.report.lcov
+  (:require
+   [clojure.java.io :as io]
+   [cloverage.report :refer [line-stats with-out-writer]]))
+
+(defn write-lcov-report
+  "Write out lcov report to *out*"
+  [forms]
+  (doseq [[rel-file file-forms] (group-by :file forms)]
+    (let [lines (line-stats file-forms)
+          instrumented (filter :instrumented? lines)]
+      (println "TN:")
+      (printf "SF:%s%n" rel-file)
+      (doseq [line instrumented]
+        (printf "DA:%d,%d%n" (:line line) (:hit line)))
+      (printf "LF:%d%n" (count instrumented))
+      (printf "LH:%d%n" (count (filter (fn [line] (> (:hit line) 0)) lines)))
+      (println "end_of_record"))))
+
+(defn report
+  "Write LCOV report to '${out-dir}/lcov.info'."
+  [^String out-dir forms]
+  (let [output-file (io/file out-dir "lcov.info")]
+    (println "Writing LCOV report to:" (.getAbsolutePath output-file))
+    (with-out-writer output-file (write-lcov-report forms))))
+

--- a/cloverage/src/cloverage/report/raw.clj
+++ b/cloverage/src/cloverage/report/raw.clj
@@ -1,0 +1,17 @@
+(ns cloverage.report.raw
+  (:require
+   [clojure.java.io :as io]
+   [cloverage.report :refer [with-out-writer]]))
+
+(defn report [^String out-dir stats covered]
+  (let [raw-data-file (io/file out-dir "raw-data.clj")
+        raw-stats-file (io/file out-dir "raw-stats.clj")]
+
+    (println "Writing raw data to:" (.getAbsolutePath raw-data-file))
+    (with-out-writer raw-data-file
+      (clojure.pprint/pprint (zipmap (range) covered)))
+
+    (println "Writing raw stats to:" (.getAbsolutePath raw-stats-file))
+    (with-out-writer raw-stats-file
+      (clojure.pprint/pprint stats))))
+

--- a/cloverage/src/cloverage/report/text.clj
+++ b/cloverage/src/cloverage/report/text.clj
@@ -1,0 +1,34 @@
+(ns cloverage.report.text
+  (:import
+   [java.io File])
+  (:require
+   [clojure.java.io :as io]
+   [cloverage.report :refer [line-stats file-stats with-out-writer]]))
+
+(defn summary [^File file forms]
+  (println "Writing text report to:" (.getAbsolutePath file))
+  (with-out-writer file
+    (printf "Lines Non-Blank Instrumented Covered Partial%n")
+    (doseq [file-info (file-stats forms)]
+      (printf "%5d %9d %12d %7d %7d %s%n"
+              (:lines file-info)
+              (- (:lines file-info) (:blank-lines file-info))
+              (:instrd-lines  file-info)
+              (:covered-lines file-info)
+              (:partial-lines file-info)
+              (:file          file-info)))))
+
+(defn report [^String out-dir forms]
+  (summary (io/file out-dir "coverage.txt") forms)
+  (doseq [[file file-forms] (group-by :file forms)
+          :when file]
+    (let [output-file (io/file out-dir file)]
+      (.mkdirs (.getParentFile output-file))
+      (with-out-writer output-file
+        (doseq [line (line-stats file-forms)]
+          (let [prefix (cond (:blank?   line) " "
+                             (:covered? line) "✔"
+                             (:partial? line) "~"
+                             (:instrumented? line) "✘"
+                             :else           "?")]
+            (println prefix (:text line))))))))

--- a/cloverage/test/cloverage/coverage_test.clj
+++ b/cloverage/test/cloverage/coverage_test.clj
@@ -232,7 +232,7 @@
     (t/is (=
            (cloverage.coverage/-main
             "-o" "out"
-            "--text" "--html" "--raw" "--emma-xml" "--coveralls"
+            "--text" "--html" "--raw" "--emma-xml" "--coveralls" "--codecov" "--lcov"
             "-x" "cloverage.sample"
             "cloverage.sample")
            0))))


### PR DESCRIPTION
> This is an incremental change with the larger aim of trying to remove the reporting (and their dependencies) out of cloverage core.

Coveralls report and codecov now use `clojure.data.json` rather than `cheshire` - rationale is that 
`clojure.data.json` has no dependencies, whereas `cheshire` relies on a number of jackson libraries.

JSON Reports are now pretty printed to make them easier for a human reader.

For all reporting backends, a line is output to STDOUT detailing where the report was written to.

Minor formatting (column alignment) on the text summary.