### PR TITLE
Abort if cyclic dependency in namespaces detected - fixes #122

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,14 @@ Include the issue number (#xxx) which will link back to the originating issue
 in github. Commentary on the change should appear as a nested, unordered list.
 
 ## 1.0.10 (WIP)
-
-Nothing yet!
+- Improvements
+  - Split out reporting into separate namespaces (#165)
+  - Stop using Cheshire for JSON output (fewer transitive dependencies) (#165)
+- Bugfixes
+  - Fix performance regression: Only call `gather-stats` once (#166)
+  - Abort if cyclic dependency in namespaces detected (#122)
 
 ## 1.0.9
-
 - Improvements
   - No more reflection warnings! (#158)
   - Colorized summary report & ability to fail build on coverage &lt; threshold (#99)

--- a/cloverage/src/cloverage/kahn.clj
+++ b/cloverage/src/cloverage/kahn.clj
@@ -40,23 +40,3 @@
            m (g n)
            g' (reduce #(update-in % [n] without %2) g m)]
        (recur g' (conj l n) (union s' (intersection (no-incoming g') m)))))))
-
-(comment
-  (def acyclic-g
-    {7 #{11 8}
-     5 #{11}
-     3 #{8 10}
-     11 #{2 9}
-     8 #{9}})
-
-  (def cyclic-g
-    {7 #{11 8}
-     5 #{11}
-     3 #{8 10}
-     11 #{2 9}
-     8 #{9}
-     2 #{11}}) ;oops, a cycle!
-
-  (kahn-sort acyclic-g) ;=> [3 5 7 8 10 11 2 9]
-  (kahn-sort cyclic-g) ;=> nil
-)

--- a/cloverage/src/cloverage/sample/cyclic_dependency.clj
+++ b/cloverage/src/cloverage/sample/cyclic_dependency.clj
@@ -1,0 +1,5 @@
+(ns cloverage.sample.cyclic-dependency
+  (:require [cloverage.sample.cyclic-dependency :as self]))
+
+(+ 1 2)
+

--- a/cloverage/src/cloverage/sample/exercise_instrumentation.clj
+++ b/cloverage/src/cloverage/sample/exercise_instrumentation.clj
@@ -1,4 +1,4 @@
-(ns cloverage.sample
+(ns cloverage.sample.exercise-instrumentation
   (:refer-clojure :exclude [loop])
   (:import java.lang.RuntimeException)
   (:use [clojure test]))

--- a/cloverage/test/cloverage/coverage_test.clj
+++ b/cloverage/test/cloverage/coverage_test.clj
@@ -11,9 +11,6 @@
         (symbol? tree) (symbol (name tree))
         :else tree))
 
-(def sample-file
-  "cloverage/sample.clj")
-
 (defn coverage-fixture [f]
   (binding [cov/*covered*         (atom [])
             cov/*instrumented-ns* "NO_SUCH_NAMESPACE"]
@@ -183,7 +180,7 @@
 
 (t/deftest test-instrument-gets-lines
   (inst/instrument #'cov/track-coverage
-                   'cloverage.sample)
+                   'cloverage.sample.exercise-instrumentation)
   (let [cov @cov/*covered*
         found (find-form cov '(+ 1 2))]
     #_(with-out-writer "out/foo"
@@ -233,6 +230,18 @@
            (cloverage.coverage/-main
             "-o" "out"
             "--text" "--html" "--raw" "--emma-xml" "--coveralls" "--codecov" "--lcov"
-            "-x" "cloverage.sample"
-            "cloverage.sample")
+            "-x" "cloverage.sample.exercise-instrumentation"
+            "cloverage.sample.exercise-instrumentation")
            0))))
+
+(t/deftest test-cyclic-dependency
+  (binding [cloverage.coverage/*exit-after-test* false]
+    (t/is
+     (thrown-with-msg?
+      RuntimeException #"Cannot instrument namespaces; there is a cyclic depdendency"
+      (cloverage.coverage/-main
+       "-o" "out"
+       "--emma-xml"
+       "-x" "cloverage.sample.cyclic-dependency"
+       "cloverage.sample.cyclic-dependency")))))
+

--- a/cloverage/test/cloverage/kahn_test.clj
+++ b/cloverage/test/cloverage/kahn_test.clj
@@ -1,0 +1,23 @@
+(ns cloverage.kahn-test
+  (:require [clojure.test :as t]
+            [cloverage.kahn :as k]))
+
+(def acyclic-g
+  {7 #{11 8}
+   5 #{11}
+   3 #{8 10}
+   11 #{2 9}
+   8 #{9}})
+
+(def cyclic-g
+  {7 #{11 8}
+   5 #{11}
+   3 #{8 10}
+   11 #{2 9}
+   8 #{9}
+   2 #{11}}) ;oops, a cycle!
+
+
+(t/deftest test-sorting
+  (t/is (= [7 3 5 11 2 10 8 9] (k/kahn-sort acyclic-g)))
+  (t/is (nil? (k/kahn-sort cyclic-g))))


### PR DESCRIPTION
- Throws a runtime exception if the namespace deps is empty
- Moved the comments in kahn.clj to be unit tests
- Reorganised test samples into separate namespace