### PR TITLE
Attempt creation of output dir ahead of use with --junit flag - fixes #167

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ in github. Commentary on the change should appear as a nested, unordered list.
 - Bugfixes
   - Fix performance regression: Only call `gather-stats` once (#166)
   - Abort if cyclic dependency in namespaces detected (#122)
+  - Attempt creation of output dir ahead of running with --junit flag (#167)
 
 ## 1.0.9
 - Improvements

--- a/cloverage/test/cloverage/coverage_test.clj
+++ b/cloverage/test/cloverage/coverage_test.clj
@@ -229,7 +229,7 @@
     (t/is (=
            (cloverage.coverage/-main
             "-o" "out"
-            "--text" "--html" "--raw" "--emma-xml" "--coveralls" "--codecov" "--lcov"
+            "--junit" "--text" "--html" "--raw" "--emma-xml" "--coveralls" "--codecov" "--lcov"
             "-x" "cloverage.sample.exercise-instrumentation"
             "cloverage.sample.exercise-instrumentation")
            0))))


### PR DESCRIPTION
Adding "--junit" to coverage_test.clj caused the test to fail with
the same error as reported in the issue.