### PR TITLE
Make form-reader fail with a helpful exception

### DIFF
--- a/cloverage/src/cloverage/sample/exercise_instrumentation.clj
+++ b/cloverage/src/cloverage/sample/exercise_instrumentation.clj
@@ -123,8 +123,7 @@
   (is (thrown? Exception (transaction-fn 1))))
 
 (letfn [(covered [] (+ 2 3))
-        (not-covered []
-                     {:and :not-tracked})
+        (not-covered [] {:and :not-tracked})
         (not-covered [] ({:preimage :image} :preimage))]
   (covered))
 

--- a/cloverage/src/cloverage/source.clj
+++ b/cloverage/src/cloverage/source.clj
@@ -29,9 +29,12 @@
     (throw (IllegalArgumentException. (str "Cannot find resource " resource)))))
 
 (defn form-reader [ns-symbol]
-  (rt/indexing-push-back-reader
-   (java.io.PushbackReader.
-    (resource-reader (resource-path ns-symbol)))))
+  (if-let [res-path (resource-path ns-symbol)]
+    (rt/indexing-push-back-reader
+     (java.io.PushbackReader.
+      (resource-reader res-path)))
+    (throw (ex-info (format "Resource path not found for namespace: %s" (name ns-symbol))
+                    {:ns-symbol ns-symbol}))))
 
 (defn forms [ns-symbol]
   (let [src (form-reader ns-symbol)]

--- a/cloverage/test/cloverage/source_test.clj
+++ b/cloverage/test/cloverage/source_test.clj
@@ -8,3 +8,10 @@
   (t/is (= (sut/forms 'cloverage.sample.multibyte-sample)
            '((ns cloverage.sample.multibyte-sample)
              (def a "あ")))))
+
+(t/deftest form-reader-test
+  "Useful exception is thrown if resource-path not found for a ns"
+  (with-redefs [sut/resource-path (constantly nil)]
+    (t/is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"Resource path not found for namespace: foo.bar"
+                            (sut/form-reader 'foo.bar)))))


### PR DESCRIPTION
The cloverage.source/resource-path function fails to find the path for a
namespace if there is a discrepancy between the name of the namespace
and it's filename. Earlier this would result in IllegalArgumentException
thrown by cloverage.source/resource-reader which didn't include any
information about the namespace and hence wasn't much helpful.

This commit modifies the cloverage.source/form-reader function to handle
the above case, and throws a more helpful exception with the namespace
included.

This change _may_ help with issue #175. 