### PR TITLE
Fixed typo

### DIFF
--- a/cloverage/src/cloverage/coverage.clj
+++ b/cloverage/src/cloverage/coverage.clj
@@ -258,7 +258,7 @@
         (println "Test namespaces: " test-nses)
 
         (if (empty? ordered-nses)
-          (throw (RuntimeException. "Cannot instrument namespaces; there is a cyclic depdendency"))
+          (throw (RuntimeException. "Cannot instrument namespaces; there is a cyclic dependency"))
           (doseq [namespace ordered-nses]
             (binding [*instrumented-ns* namespace]
               (if nops?

--- a/cloverage/test/cloverage/coverage_test.clj
+++ b/cloverage/test/cloverage/coverage_test.clj
@@ -238,7 +238,7 @@
   (binding [cloverage.coverage/*exit-after-test* false]
     (t/is
      (thrown-with-msg?
-      RuntimeException #"Cannot instrument namespaces; there is a cyclic depdendency"
+      RuntimeException #"Cannot instrument namespaces; there is a cyclic dependency"
       (cloverage.coverage/-main
        "-o" "out"
        "--emma-xml"


### PR DESCRIPTION
Fixed typo on an exception message. Filing separately from other changes, as this one should be trivial to review.