### PR TITLE
Allow external runners to be loaded from other dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add [![Clojars Project](http://clojars.org/lein-cloverage/latest-version.svg)](h
 
 ## Testing frameworks support
 
-Cloverage uses clojure.test by default. If you prefer use midje, pass the `--runner :midje` flag. (In older versions of Cloverage, you had to wrap your midje tests in clojure.test's deftest. This is no longer necessary.)
+Cloverage uses `clojure.test` by default. If you prefer use `midje`, pass the `--runner :midje` flag. (In older versions of Cloverage, you had to wrap your midje tests in clojure.test's deftest. This is no longer necessary.) Other test libraries may ship with their own support for Cloverage external to this library; see their documentation for details.
 
 ## Usage
 

--- a/cloverage/src/cloverage/coverage.clj
+++ b/cloverage/src/cloverage/coverage.clj
@@ -128,7 +128,7 @@
            ["-d" "--[no-]debug"
             "Output debugging information to stdout." :default false]
            ["-r" "--runner"
-            "Specify which test runner to use. Currently supported runners are `clojure.test` and `midje`."
+            "Specify which test runner to use. Built-in runners are `clojure.test` and `midje`."
             :default :clojure.test
             :parse-fn parse-kw-str]
            ["--[no-]nop" "Instrument with noops." :default false]
@@ -207,7 +207,7 @@
 
 (defmethod runner-fn :default [_]
   (throw (IllegalArgumentException.
-          "Currently supported runners are only `clojure.test` and `midje`.")))
+          "Runner not found. Built-in runners are `clojure.test` and `midje`.")))
 
 (defn- coverage-under? [forms failure-threshold]
   (when (pos? failure-threshold)
@@ -269,6 +269,10 @@
             (mark-loaded namespace)))
 
         (println "Instrumented namespaces.")
+        ;; load runner multimethod definition from other dependencies
+        (when-not (#{:clojure.test :midje} runner)
+          (try (require (symbol (format "%s.cloverage" (name runner))))
+               (catch java.io.FileNotFoundException _)))
         (let [test-result (when-not (empty? test-nses)
                             (if (and junit?
                                      (not (= runner :clojure.test)))


### PR DESCRIPTION
When a file $RUNNER/cloverage.clj exists on the classpath, assume it
contains a definition for the `runner-fn` multimethod and load
it. This allows third-party testing libraries like `circleci.test` to
ship with their own cloverage support external to cloverage itself.