### PR TITLE
Update clojure.tools.logging dependency

### DIFF
--- a/cloverage/project.clj
+++ b/cloverage/project.clj
@@ -18,7 +18,7 @@
                  :deploy-via :clojars}
   :dependencies [[org.clojure/tools.reader "1.0.0-beta3"]
                  [org.clojure/tools.cli "0.3.5"]
-                 [org.clojure/tools.logging "0.3.1"]
+                 [org.clojure/tools.logging "0.4.0"]
                  [org.clojure/data.xml "0.0.8"]
                  [org.clojure/data.json "0.2.6"]
                  [bultitude "0.2.8"]


### PR DESCRIPTION
I'm hitting dependency conflicts for `clojure.tools.logging` in a suite of libraries that use leiningen's `:pedantic? :abort` setting.

The workaround is to add an explicit dependency on `cloverage` with an exclusion so I'm not blocked.

I know you've requested PRs to include a CHANGELOG update, this doesn't feel changelog-worthy to me but I am happy to provide one if you pefer.