### PR TITLE
[Fixes #183] Honor namespace regex filters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,19 +3,17 @@ lein: 2.7.1
 sudo: false
 
 install:
-  - (cd cloverage && lein deps)
-  - (cd lein-cloverage && lein deps)
   # Get recent node:
   - . $HOME/.nvm/nvm.sh
   - nvm install stable
   - nvm use stable
-  - npm install
+  - npm install -g eclint
 
 before_script:
-  - npm install -g eclint
   - eclint check .* **
   - (cd cloverage && lein cljfmt check)
   - (cd lein-cloverage && lein cljfmt check)
+
 script:
   - (cd cloverage && lein test)
   - (cd lein-cloverage && lein test)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ in github. Commentary on the change should appear as a nested, unordered list.
 
 ## 1.0.11 (WIP)
 
-Nothing yet :-)
+- Bugfixes
+  - Fix the handling of --ns-regex and --test-ns-regex (#183)
 
 ## 1.0.10
 - Improvements

--- a/cloverage/src/cloverage/coverage.clj
+++ b/cloverage/src/cloverage/coverage.clj
@@ -145,11 +145,13 @@
             :default []
             :parse-fn (collecting-args-parser)]
            ["-p" "--src-ns-path"
-            "Path (string) to directory containing source code namespaces."
-            :default nil]
+            "Path (string) to directory containing source code namespaces (can be repeated)."
+            :default []
+            :parse-fn (collecting-args-parser)]
            ["-s" "--test-ns-path"
-            "Path (string) to directory containing test namespaces."
-            :default nil]
+            "Path (string) to directory containing test namespaces (can be repeated)."
+            :default []
+            :parse-fn (collecting-args-parser)]
            ["-x" "--extra-test-ns"
             "Additional test namespace (string) to add (can be repeated)."
             :default  []
@@ -160,16 +162,17 @@
   (binding [*ns* (find-ns 'clojure.core)]
     (eval `(dosync (alter clojure.core/*loaded-libs* conj '~namespace)))))
 
-(defn find-nses [ns-path regex-patterns]
-  "Given ns-path and regex-patterns returns:
-  * empty sequence when ns-path is nil and regex-patterns is empty
-  * all namespaces on ns-path (if regex-patterns is empty)
-  * all namespaces on the classpath that match any of the regex-patterns (if ns-path is nil)
-  * namespaces on ns-path that match any of the regex-patterns"
+(defn find-nses [ns-paths regex-patterns]
+  "Given ns-paths and regex-patterns returns:
+  * empty sequence when ns-paths is empty and regex-patterns is empty
+  * all namespaces on all ns-paths (if regex-patterns is empty)
+  * all namespaces on the classpath that match any of the regex-patterns (if ns-paths is empty)
+  * namespaces on ns-paths that match any of the regex-patterns"
   (let [namespaces (->> (cond
-                          (and (nil? ns-path) (empty? regex-patterns)) '()
-                          (nil? ns-path) (blt/namespaces-on-classpath)
-                          :else (blt/namespaces-on-classpath :classpath ns-path))
+                          (and (empty? ns-paths) (empty? regex-patterns)) '()
+                          (empty? ns-paths) (blt/namespaces-on-classpath)
+                          :else (mapcat #(blt/namespaces-on-classpath :classpath %)
+                                        ns-paths))
                         (map name))]
     (if (seq regex-patterns)
       (filter (fn [namespace] (some #(re-matches % namespace) regex-patterns))
@@ -241,13 +244,13 @@
         ns-regexs       (map re-pattern (:ns-regex opts))
         test-regexs     (map re-pattern (:test-ns-regex opts))
         exclude-regex   (map re-pattern (:ns-exclude-regex opts))
-        ns-path         (:src-ns-path opts)
+        ns-paths        (:src-ns-path opts)
         runner          (:runner opts)
-        test-ns-path    (:test-ns-path opts)
+        test-ns-paths   (:test-ns-path opts)
         namespaces      (set/difference
-                         (set (concat add-nses (find-nses ns-path ns-regexs)))
-                         (set (find-nses ns-path exclude-regex)))
-        test-nses       (concat extra-test-nses (find-nses test-ns-path test-regexs))
+                         (set (concat add-nses (find-nses ns-paths ns-regexs)))
+                         (set (find-nses ns-paths exclude-regex)))
+        test-nses       (concat extra-test-nses (find-nses test-ns-paths test-regexs))
         ordered-nses    (dep/in-dependency-order (map symbol namespaces))]
     (if help?
       (println help)

--- a/cloverage/test/cloverage/coverage_test.clj
+++ b/cloverage/test/cloverage/coverage_test.clj
@@ -202,26 +202,26 @@
 
 (t/deftest test-find-nses
   (t/testing "empty sequence is returned when neither paths nor regexs are provided"
-    (t/is (empty? (cov/find-nses nil []))))
+    (t/is (empty? (cov/find-nses [] []))))
   (t/testing "all namespaces in a directory get returned when only path is provided"
-    (t/is (compare-colls (cov/find-nses "test/cloverage/sample" [])
+    (t/is (compare-colls (cov/find-nses ["test/cloverage/sample"] [])
                          ["cloverage.sample.dummy-sample"
                           "cloverage.sample.read-eval-sample"
                           "cloverage.sample.multibyte-sample"])))
   (t/testing "only matching namespaces (from classpath) are returned when only
              regex patterns are provided:"
     (t/testing "single pattern case"
-      (t/is (= (cov/find-nses nil [#"^cloverage\.sample\.read.*$"])
+      (t/is (= (cov/find-nses [] [#"^cloverage\.sample\.read.*$"])
                ["cloverage.sample.read-eval-sample"])))
     (t/testing "multiple patterns case"
-      (t/is (compare-colls (cov/find-nses nil [#"^cloverage\.sample\.read.*$"
-                                               #"^cloverage\..*coverage.*$"])
+      (t/is (compare-colls (cov/find-nses [] [#"^cloverage\.sample\.read.*$"
+                                              #"^cloverage\..*coverage.*$"])
                            ["cloverage.sample.read-eval-sample"
                             "cloverage.coverage-test"
                             "cloverage.coverage"]))))
   (t/testing "only matching namespaces from a directory are returned when both path
              and patterns are provided"
-    (t/is (= (cov/find-nses "test/cloverage/sample" [#".*dummy.*"])
+    (t/is (= (cov/find-nses ["test/cloverage/sample"] [#".*dummy.*"])
              ["cloverage.sample.dummy-sample"]))))
 
 (t/deftest test-main

--- a/lein-cloverage/project.clj
+++ b/lein-cloverage/project.clj
@@ -15,6 +15,5 @@
                  :deploy-via :clojars}
   :deploy-repositories [["clojars" {:username :env/clojars_username :password :env/clojars_password :sign-releases false}]]
   :min-lein-version "2.0.0"
-  :dependencies [[bultitude "0.2.8"]]
   :profiles {:dev {:plugins [[lein-cljfmt "0.5.6"]]}}
   :eval-in-leiningen true)

--- a/lein-cloverage/src/leiningen/cloverage.clj
+++ b/lein-cloverage/src/leiningen/cloverage.clj
@@ -1,9 +1,5 @@
 (ns leiningen.cloverage
-  (:require [leiningen.run :as run]
-            [bultitude.core :as blt]))
-
-(defn ns-names-for-dirs [dirs]
-  (map name (mapcat blt/namespaces-in-dir dirs)))
+  (:require [leiningen.run :as run]))
 
 (defn get-lib-version []
   (or (System/getenv "CLOVERAGE_VERSION") "RELEASE"))
@@ -22,14 +18,12 @@
   Specify -o OUTPUTDIR for output directory, for other options run
   `lein cloverage --help`."
   [project & args]
-  (let [source-namespaces (ns-names-for-dirs (:source-paths project))
-        test-namespace    (ns-names-for-dirs (:test-paths project))
-        project (if (already-has-cloverage? project)
+  (let [project (if (already-has-cloverage? project)
                   project
                   (update-in project [:dependencies]
                              conj    ['cloverage (get-lib-version)]))]
     (apply run/run project
            "-m" "cloverage.coverage"
-           (concat (mapcat  #(list "-x" %) test-namespace)
-                   args
-                   source-namespaces))))
+           (concat (mapcat #(list "-p" %) (:source-paths project))
+                   (mapcat #(list "-s" %) (:test-paths project))
+                   args))))


### PR DESCRIPTION
With this fix `lein-cloverage` no longer attempts to enumerate the namespaces in the project. Instead, `lein-cloverage` now passes the project's source and test paths into `cloverage`, where the namespace enumeration is done with regex filtering applied.

To support this change, the command line flags `--src-ns-path` and `--test-ns-path` can now be specified multiple times, since `project.clj` may specify multiple paths.