### PR TITLE
(Revert (Revert "[Fixes #143] add kibit and eastwood to CI"))

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,30 +2,79 @@ version: 2.0
 jobs:
   build:
     docker:
-      - image: clojure:lein-2.7.1
+      - image: clojure:lein-2.8.1
     steps:
       - checkout
+
+      ################################################################################
+      # setup dependencies
+
       - restore_cache:
           keys:
             - v1-jars-{{ checksum "cloverage/project.clj" }}-{{ checksum "lein-cloverage/project.clj" }}
             - v1-jars-
       - run:
-          name: Install cloverage dependencies
+          name: (cloverage) install dependencies
           command: lein deps
           working_directory: ./cloverage
       - run:
-          name: Install lein-cloverage dependencies
+          name: (lein-cloverage) install dependencies
           command: lein deps
           working_directory: ./lein-cloverage
       - save_cache:
           key: v1-jars-{{ checksum "cloverage/project.clj" }}-{{ checksum "lein-cloverage/project.clj" }}
           paths:
             - ~/.m2
+
+      ################################################################################
+      # cloverage tests
+
       - run:
-          name: Run cloverage tests
-          command: lein test
+          name: (cloverage) tests
+          # "with-profile +sample" is needed to pull in a file with circular dependencies
+          # that the eastwood check (see below) isn't able to instrument.
+          command: lein with-profile +sample test
           working_directory: ./cloverage
       - run:
-          name: Run lein-cloverage tests
+          name: (cloverage) cljfmt
+          command: lein cljfmt check
+          working_directory: ./cloverage
+      - run:
+          name: (cloverage) eastwood 1
+          # excluding the "exercise-instrumentation" namespace because it intentionally does
+          # things that eastwood will also flag.
+          command: lein eastwood "{:exclude-namespaces [cloverage.sample.exercise-instrumentation]}"
+          working_directory: ./cloverage
+      - run:
+          # running just the "exercise-instrumentation" namespace with certain linters turned off
+          name: (cloverage) eastwood 2
+          command: lein eastwood "{:namespaces [cloverage.sample.exercise-instrumentation]
+                                   :exclude-linters [:unused-ret-vals
+                                                     :suspicious-test
+                                                     :constant-test
+                                                     :wrong-pre-post]}"
+          working_directory: ./cloverage
+      - run:
+          name: (cloverage) kibit
+          command: lein kibit
+          working_directory: ./cloverage
+
+      ################################################################################
+      # lein-cloverage tests
+
+      - run:
+          name: (lein-cloverage) tests
           command: lein test
+          working_directory: ./lein-cloverage
+      - run:
+          name: (lein-cloverage) cljfmt
+          command: lein cljfmt check
+          working_directory: ./lein-cloverage
+      - run:
+          name: (lein-cloverage) eastwood
+          command: lein eastwood
+          working_directory: ./lein-cloverage
+      - run:
+          name: (lein-cloverage) kibit
+          command: lein kibit
           working_directory: ./lein-cloverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: clojure
-lein: 2.7.1
+lein: 2.8.1
 sudo: false
 
 install:
@@ -11,11 +11,20 @@ install:
 
 before_script:
   - eclint check .* **
-  - (cd cloverage && lein cljfmt check)
-  - (cd lein-cloverage && lein cljfmt check)
+  - |
+    (cd cloverage && \
+        lein do cljfmt check, \
+                eastwood "{:exclude-namespaces [cloverage.sample.exercise-instrumentation]}", \
+                eastwood "{:namespaces [cloverage.sample.exercise-instrumentation] \
+                           :exclude-linters [:unused-ret-vals \
+                                             :suspicious-test \
+                                             :constant-test \
+                                             :wrong-pre-post]}", \
+                kibit)
+  - (cd lein-cloverage && lein do cljfmt check, eastwood, kibit)
 
 script:
-  - (cd cloverage && lein test)
+  - (cd cloverage && lein with-profile +sample test)
   - (cd lein-cloverage && lein test)
 
 cache:

--- a/cloverage/project.clj
+++ b/cloverage/project.clj
@@ -16,18 +16,22 @@
   :plugins [[lein-release "1.0.9"]]
   :lein-release {:scm :git ; Because we're not in the top-level directory, so it doesn't auto-detect
                  :deploy-via :clojars}
-  :dependencies [[org.clojure/tools.reader "1.0.0-beta3"]
+  :dependencies [[org.clojure/tools.reader "1.1.2"]
                  [org.clojure/tools.cli "0.3.5"]
                  [org.clojure/tools.logging "0.4.0"]
                  [org.clojure/data.xml "0.0.8"]
                  [org.clojure/data.json "0.2.6"]
                  [bultitude "0.2.8"]
-                 [riddley "0.1.12"]
+                 [riddley "0.1.14"]
                  [slingshot "0.12.2"]]
   :profiles {:dev    {:aot          ^:replace []
                       :dependencies [[org.clojure/clojure "1.8.0"]]
-                      :plugins [[lein-cljfmt "0.5.6"]]
+                      :plugins [[lein-cljfmt "0.5.7"]
+                                [jonase/eastwood "0.2.5"]
+                                [lein-kibit "0.1.6"]]
+                      :eastwood {:exclude-linters [:no-ns-form-found]}
                       :global-vars {*warn-on-reflection* true}}
+             :sample {:source-paths ["sample"]}
              :1.4    {:dependencies [[org.clojure/clojure "1.4.0"]]}
              :1.5    {:dependencies [[org.clojure/clojure "1.5.1"]]}
              :1.6    {:dependencies [[org.clojure/clojure "1.6.0"]]}

--- a/cloverage/sample/cloverage/sample/cyclic_dependency.clj
+++ b/cloverage/sample/cloverage/sample/cyclic_dependency.clj
@@ -1,5 +1,4 @@
 (ns cloverage.sample.cyclic-dependency
   (:require [cloverage.sample.cyclic-dependency :as self]))
 
-(+ 1 2)
-
+(+ 40 2)

--- a/cloverage/src/cloverage/coverage.clj
+++ b/cloverage/src/cloverage/coverage.clj
@@ -162,21 +162,20 @@
   (binding [*ns* (find-ns 'clojure.core)]
     (eval `(dosync (alter clojure.core/*loaded-libs* conj '~namespace)))))
 
-(defn find-nses [ns-paths regex-patterns]
+(defn find-nses
   "Given ns-paths and regex-patterns returns:
   * empty sequence when ns-paths is empty and regex-patterns is empty
   * all namespaces on all ns-paths (if regex-patterns is empty)
   * all namespaces on the classpath that match any of the regex-patterns (if ns-paths is empty)
   * namespaces on ns-paths that match any of the regex-patterns"
-  (let [namespaces (->> (cond
+  [ns-paths regex-patterns]
+  (let [namespaces (map name
+                        (cond
                           (and (empty? ns-paths) (empty? regex-patterns)) '()
                           (empty? ns-paths) (blt/namespaces-on-classpath)
-                          :else (mapcat #(blt/namespaces-on-classpath :classpath %)
-                                        ns-paths))
-                        (map name))]
+                          :else (mapcat #(blt/namespaces-on-classpath :classpath %) ns-paths)))]
     (if (seq regex-patterns)
-      (filter (fn [namespace] (some #(re-matches % namespace) regex-patterns))
-              namespaces)
+      (filter (fn [ns] (some #(re-matches % ns) regex-patterns)) namespaces)
       namespaces)))
 
 (defn- resolve-var [sym]
@@ -276,10 +275,10 @@
         (when-not (#{:clojure.test :midje} runner)
           (try (require (symbol (format "%s.cloverage" (name runner))))
                (catch java.io.FileNotFoundException _)))
-        (let [test-result (when-not (empty? test-nses)
-                            (if (and junit?
-                                     (not (= runner :clojure.test)))
-                              (throw (RuntimeException. "Junit output only supported for clojure.test at present"))
+        (let [test-result (when (seq test-nses)
+                            (if (and junit? (not= runner :clojure.test))
+                              (throw (RuntimeException.
+                                      "Junit output only supported for clojure.test at present"))
                               ((runner-fn opts) (map symbol test-nses))))
               forms       (rep/gather-stats @*covered*)
               ;; sum up errors as in lein test

--- a/cloverage/src/cloverage/debug.clj
+++ b/cloverage/src/cloverage/debug.clj
@@ -1,14 +1,13 @@
 (ns cloverage.debug
   (:use [clojure.java.io :only [writer]])
-  (:require clojure.pprint))
+  (:require [clojure.pprint]))
 
 (def ^:dynamic *debug* false)
 ;; debug output
 (defn tprn [& args]
   (when *debug*
-    (do
-      (doall (map clojure.pprint/pprint args))
-      (newline))))
+    (run! clojure.pprint/pprint args)
+    (newline)))
 
 (defn tprnl [& args]
   (when *debug*
@@ -23,4 +22,4 @@
     (with-open [ou (writer (str "debug-" name))]
       (binding [*out* ou
                 *print-meta* true]
-        (doall (map prn forms))))))
+        (run! prn forms)))))

--- a/cloverage/src/cloverage/dependency.clj
+++ b/cloverage/src/cloverage/dependency.clj
@@ -41,7 +41,7 @@
 (defn- spec-dependencies [libspec]
   (cond
     (symbol?  libspec) [libspec]
-    (libspec? libspec) [(first (filter (complement keyword?) libspec))]
+    (libspec? libspec) [(first (remove keyword? libspec))]
     (vector?  libspec) (let [[prefix & args] libspec]
                          (map #(symbol (str prefix \. (if (seq? %) (first %) %))) args))))
 

--- a/cloverage/src/cloverage/instrument.clj
+++ b/cloverage/src/cloverage/instrument.clj
@@ -1,14 +1,15 @@
 (ns cloverage.instrument
   (:use [slingshot.slingshot :only [throw+]]
         [clojure.java.io :only [writer]]
-        [clojure.string  :only [split]]
-        [cloverage debug source])
+        [clojure.string  :only [split]])
   (:require [clojure.set :as set]
             [clojure.test :as test]
             [clojure.tools.logging :as log]
             [cloverage.rewrite :refer [unchunk]]
             [clojure.tools.reader :as r]
-            [riddley.walk :refer [macroexpand-all]]))
+            [riddley.walk :refer [macroexpand-all]]
+            [cloverage.debug :refer :all]
+            [cloverage.source :refer :all]))
 
 (defn iobj? [form]
   (and
@@ -162,20 +163,22 @@
   [f line]
   (partial wrap f line))
 
-(defn wrap-binding [f line-hint [args & body :as form]]
+(defn wrap-binding
   "Wrap a let/loop binding
 
    e.g. - `a (+ a b)`       (let or loop)"
+  [f line-hint [args & body :as form]]
   (tprnl "Wrapping overload" args body)
   (let [line (or (:line (meta form)) line-hint)]
     (let [wrapped (doall (map (wrapper f line) body))]
       `(~args ~@wrapped))))
 
-(defn wrap-overload [f line-hint [args & body :as form]]
+(defn wrap-overload
   "Wrap a single function overload.
 
    e.g. - ([a b] (+ a b)) or
           ([n] {:pre [(> n 0)]} (/ 1 n))"
+  [f line-hint [args & body :as form]]
   (tprnl "Wrapping function overload" args body)
   (let [line  (or (:line (meta form)) line-hint)
         conds (when (and (next body) (map? (first body)))
@@ -391,9 +394,9 @@
 (defmethod do-wrap :defmulti [f line [defm-symbol name & other] _]
   ;; wrap defmulti to avoid partial coverage warnings due to internal
   ;; clojure code (stupid checks for wrong syntax)
-  (let [docstring     (if (string? (first other)) (first other) nil)
+  (let [docstring     (when (string? (first other)) (first other))
         other         (if docstring (next other) other)
-        attr-map      (if (map? (first other)) (first other) nil)
+        attr-map      (when (map? (first other)) (first other))
         other         (if (map? (first other)) (next other) other)
         dispatch-form (first other)
         other         (rest other)]
@@ -437,10 +440,9 @@
                               (with-out-str (prn form)))
                          e))))
              (recur (conj instrumented-forms wrapped)))
-           (do
-             (let [rforms (reverse instrumented-forms)]
-               (dump-instrumented rforms lib)
-               rforms))))))))
+           (let [rforms (reverse instrumented-forms)]
+             (dump-instrumented rforms lib)
+             rforms)))))))
 
 (defn nop
   "Instrument form with expressions that do nothing."

--- a/cloverage/src/cloverage/report/console.clj
+++ b/cloverage/src/cloverage/report/console.clj
@@ -31,22 +31,22 @@
     (throw (IllegalArgumentException. "High-watermark cannot be more than 100%"))
 
     (> low-watermark high-watermark)
-    (throw (IllegalArgumentException. "Low-watermark must be under high-watermark")))
+    (throw (IllegalArgumentException. "Low-watermark must be under high-watermark"))
 
-  :else
-  (letfn [(f
-            ([pct] (f pct (format formatter pct)))
-            ([pct text]
-             (cond
-               (< pct low-watermark)
-               (ansi :red text)
+    :else
+    (letfn [(f
+              ([pct] (f pct (format formatter pct)))
+              ([pct text]
+               (cond
+                 (< pct low-watermark)
+                 (ansi :red text)
 
-               (>= pct high-watermark)
-               (ansi :green text)
+                 (>= pct high-watermark)
+                 (ansi :green text)
 
-               :else
-               (ansi :yellow text))))]
-    f))
+                 :else
+                 (ansi :yellow text))))]
+      f)))
 
 (defn pad-right [width text]
   (let [len (printable-count text)]
@@ -60,12 +60,13 @@
                            (printable-count (str k))
                            (map #(printable-count (str (get % k))) rows)))
                   ks)
-          spacers (map #(apply str (repeat % "-")) widths)
+          spacers (map #(cs/join (repeat % "-")) widths)
           fmt-row (fn [leader divider trailer row]
                     (str leader
-                         (apply str (interpose divider
-                                               (for [[col w] (map vector (map #(get row %) ks) widths)]
-                                                 (pad-right w (str col)))))
+                         (cs/join
+                          divider
+                          (for [[col w] (map vector (map #(get row %) ks) widths)]
+                            (pad-right w (str col))))
                          trailer))]
       (println)
       (println (fmt-row "|-" "-+-" "-|" (zipmap ks spacers)))

--- a/cloverage/src/cloverage/report/coveralls.clj
+++ b/cloverage/src/cloverage/report/coveralls.clj
@@ -12,7 +12,7 @@
         size (* 2 (.getDigestLength algorithm))
         raw (.digest algorithm (.getBytes s))
         sig (.toString (BigInteger. 1 raw) 16)
-        padding (apply str (repeat (- size (count sig)) "0"))]
+        padding (s/join (repeat (- size (count sig)) "0"))]
     (str padding sig)))
 
 (defn- env?

--- a/cloverage/src/cloverage/report/emma_xml.clj
+++ b/cloverage/src/cloverage/report/emma_xml.clj
@@ -5,7 +5,7 @@
    [cloverage.report :refer [file-stats]]))
 
 (defn- cov [t left right]
-  (let [percent (if (> right 0) (float (* 100 (/ left right))) 0.0)]
+  (let [percent (if (pos? right) (float (* 100 (/ left right))) 0.0)]
     [:coverage {:type t :value (format "%.0f%% (%d/%d)" percent left right)}]))
 
 (defn- do-counters [stats]

--- a/cloverage/src/cloverage/report/html.clj
+++ b/cloverage/src/cloverage/report/html.clj
@@ -17,9 +17,10 @@
    \/ "&#x2F;"})
 
 ;; Java 7 has a much nicer API, but this supports Java 6.
-(defn relative-path [^File target-dir ^File base-dir]
-  ^{:doc "Return the path to target-dir relative to base-dir.
-          Both arguments are java.io.File"}
+(defn relative-path
+  "Return the path to target-dir relative to base-dir.
+Both arguments are java.io.File"
+  [^File target-dir ^File base-dir]
   (loop [target-file (.getAbsoluteFile target-dir)
          base-file   (.getAbsoluteFile base-dir)
          postpend    ""
@@ -44,15 +45,15 @@
 
 (defn- td-bar [total & parts]
   (str "<td class=\"with-bar\">"
-       (apply str
-              (map (fn [[key cnt]]
-                     (if (> cnt 0)
-                       (format "<div class=\"%s\"
+       (cs/join
+        (map (fn [[key cnt]]
+               (if (pos? cnt)
+                 (format "<div class=\"%s\"
                                 style=\"width:%s%%;
                                         float:left;\"> %d </div>"
-                               (name key) (/ (* 100.0 cnt) total) cnt)
-                       ""))
-                   parts))
+                         (name key) (/ (* 100.0 cnt) total) cnt)
+                 ""))
+             parts))
        "</td>"))
 
 (defn- td-num [content]
@@ -77,7 +78,7 @@
       (println (td-num "Forms %"))
       (println "    <td class=\"with-bar\"> Lines </td>")
       (println (td-num "Lines %"))
-      (println (apply str (map td-num ["Total" "Blank" "Instrumented"])))
+      (println (cs/join (map td-num ["Total" "Blank" "Instrumented"])))
       (println "   </tr></thead>")
       (doseq [file-stat (sort-by :lib (file-stats forms))]
         (let [filepath  (:file file-stat)
@@ -104,7 +105,7 @@
           (println (td-num (format "%.2f %%" (/ (* 100.0 (+ covered partial))
                                                 instrd))))
           (println
-           (apply str (map td-num [lines blank instrd])))
+           (cs/join (map td-num [lines blank instrd])))
           (println "</tr>")))
       (println "<tr><td>Totals:</td>")
       (println (td-bar nil))

--- a/cloverage/src/cloverage/report/lcov.clj
+++ b/cloverage/src/cloverage/report/lcov.clj
@@ -14,7 +14,7 @@
       (doseq [line instrumented]
         (printf "DA:%d,%d%n" (:line line) (:hit line)))
       (printf "LF:%d%n" (count instrumented))
-      (printf "LH:%d%n" (count (filter (fn [line] (> (:hit line) 0)) lines)))
+      (printf "LH:%d%n" (count (filter (fn [line] (pos? (:hit line))) lines)))
       (println "end_of_record"))))
 
 (defn report

--- a/cloverage/src/cloverage/sample/exercise_instrumentation.clj
+++ b/cloverage/src/cloverage/sample/exercise_instrumentation.clj
@@ -5,16 +5,16 @@
 
 '()
 
-(+ 1 2)
+(+ 40 2)
 
 (+ (* 2 3)
    (/ 12 3))
 
-(let [a (+ 1 2)
+(let [a (+ 40 2)
       b (+ 3 4)]
   (* a b))
 
-{:a (+ 1 2)
+{:a (+ 40 2)
  (/ 4 2) "two"}
 
 (defn function-with-empty-list []
@@ -46,7 +46,8 @@
 (defmethod mixed-coverage-multi String
   ;; fully covered
   [x]
-  (do x))
+  (do (#()) ; no-op
+      x))
 
 (defmethod mixed-coverage-multi Long
   ;; partially covered
@@ -140,7 +141,7 @@
    :ok))
 
 (defn locals-dont-crash []
-  (let [letfn #(+ % 1)]
+  (let [letfn #(+ % 42)]
     (letfn 2)))
 
 (defn inline-use []

--- a/cloverage/test/cloverage/coverage_test.clj
+++ b/cloverage/test/cloverage/coverage_test.clj
@@ -5,8 +5,9 @@
             [riddley.walk :as rw])
   (:import java.io.File))
 
-(defn- denamespace [tree]
+(defn- denamespace
   "Helper function to allow backticking w/o namespace interpolation."
+  [tree]
   (cond (seq? tree) (map denamespace tree)
         (symbol? tree) (symbol (name tree))
         :else tree))
@@ -173,7 +174,7 @@
                                     :caught)
                                   (finally
                                     (swap! cloverage.coverage-test/ran-finally (constantly true))))))))
-  (= true @ran-finally))
+  (t/is (= true @ran-finally)))
 
 (defn find-form [cov form]
   (some #(and (= form (:form %)) %) cov))
@@ -182,7 +183,7 @@
   (inst/instrument #'cov/track-coverage
                    'cloverage.sample.exercise-instrumentation)
   (let [cov @cov/*covered*
-        found (find-form cov '(+ 1 2))]
+        found (find-form cov '(+ 40 2))]
     #_(with-out-writer "out/foo"
         (doseq [form-info cov]
           (println form-info)))
@@ -195,9 +196,10 @@
   (t/is (expand= `(cov/capture 0 (~'new java.io.File (cov/capture 1 "foo/bar")))
                  (inst/wrap #'cov/track-coverage 0 '(new java.io.File "foo/bar")))))
 
-(defn- compare-colls [& colls]
+(defn- compare-colls
   "Given N collections compares them. Returns true if collections have same
   elements (order does not matter)."
+  [& colls]
   (apply = (map frequencies colls)))
 
 (t/deftest test-find-nses

--- a/cloverage/test/cloverage/sample/raw-data.clj
+++ b/cloverage/test/cloverage/sample/raw-data.clj
@@ -2,17 +2,17 @@
  {:form
   (ns
    cloverage.sample.dummy-sample
-    "This namespace is necessary for redundancy.\n  It allows us to check whether regexs in combination with path parameters work."),
+    "This namespace is necessary for redundancy.\n  It allows us to check whether regexs in combination with path parameters work.")
   :full-form
   (ns
    cloverage.sample.dummy-sample
-    "This namespace is necessary for redundancy.\n  It allows us to check whether regexs in combination with path parameters work."),
-  :tracked true,
-  :line 1,
-  :lib cloverage.sample.dummy-sample,
-  :file "cloverage/sample/dummy_sample.clj",
-  :covered true,
-  :hits 1},
+    "This namespace is necessary for redundancy.\n  It allows us to check whether regexs in combination with path parameters work.")
+  :tracked true
+  :line 1
+  :lib cloverage.sample.dummy-sample
+  :file "cloverage/sample/dummy_sample.clj"
+  :covered true
+  :hits 1}
  1
  {:form
   (def
@@ -22,7 +22,7 @@
        (cloverage.instrument/wrapm
         cloverage.coverage/track-coverage
         5
-        (println "Hello, World!"))))),
+        (println "Hello, World!")))))
   :full-form
   (def
     dummy-function
@@ -31,15 +31,15 @@
        (cloverage.instrument/wrapm
         cloverage.coverage/track-coverage
         5
-        (println "Hello, World!"))))),
-  :tracked true,
-  :line 5,
-  :lib cloverage.sample.dummy-sample,
-  :file "cloverage/sample/dummy_sample.clj",
-  :covered true,
-  :hits 1},
+        (println "Hello, World!")))))
+  :tracked true
+  :line 5
+  :lib cloverage.sample.dummy-sample
+  :file "cloverage/sample/dummy_sample.clj"
+  :covered true
+  :hits 1}
  2
- {:form (println "Hello, World!"),
+ {:form (println "Hello, World!")
   :full-form
   ((cloverage.instrument/wrapm
     cloverage.coverage/track-coverage
@@ -48,22 +48,22 @@
    (cloverage.instrument/wrapm
     cloverage.coverage/track-coverage
     7
-    "Hello, World!")),
-  :tracked true,
-  :line 7,
-  :lib cloverage.sample.dummy-sample,
-  :file "cloverage/sample/dummy_sample.clj"},
+    "Hello, World!"))
+  :tracked true
+  :line 7
+  :lib cloverage.sample.dummy-sample
+  :file "cloverage/sample/dummy_sample.clj"}
  3
- {:form println,
-  :full-form println,
-  :tracked true,
-  :line 7,
-  :lib cloverage.sample.dummy-sample,
-  :file "cloverage/sample/dummy_sample.clj"},
+ {:form println
+  :full-form println
+  :tracked true
+  :line 7
+  :lib cloverage.sample.dummy-sample
+  :file "cloverage/sample/dummy_sample.clj"}
  4
- {:form "Hello, World!",
-  :full-form "Hello, World!",
-  :tracked true,
-  :line 7,
-  :lib cloverage.sample.dummy-sample,
+ {:form "Hello, World!"
+  :full-form "Hello, World!"
+  :tracked true
+  :line 7
+  :lib cloverage.sample.dummy-sample
   :file "cloverage/sample/dummy_sample.clj"}}

--- a/cloverage/test/cloverage/sample/raw-stats.clj
+++ b/cloverage/test/cloverage/sample/raw-stats.clj
@@ -1,35 +1,35 @@
-({:text "(ns cloverage.sample.dummy-sample",
-  :line 1,
-  :lib cloverage.sample.dummy-sample,
-  :file "cloverage/sample/dummy_sample.clj",
+({:text "(ns cloverage.sample.dummy-sample"
+  :line 1
+  :lib cloverage.sample.dummy-sample
+  :file "cloverage/sample/dummy_sample.clj"
   :form
   (ns
    cloverage.sample.dummy-sample
-    "This namespace is necessary for redundancy.\n  It allows us to check whether regexs in combination with path parameters work."),
+    "This namespace is necessary for redundancy.\n  It allows us to check whether regexs in combination with path parameters work.")
   :full-form
   (ns
    cloverage.sample.dummy-sample
-    "This namespace is necessary for redundancy.\n  It allows us to check whether regexs in combination with path parameters work."),
-  :tracked true,
-  :covered true,
+    "This namespace is necessary for redundancy.\n  It allows us to check whether regexs in combination with path parameters work.")
+  :tracked true
+  :covered true
   :hits 1}
- {:text "  \"This namespace is necessary for redundancy.",
-  :line 2,
-  :lib cloverage.sample.dummy-sample,
+ {:text "  \"This namespace is necessary for redundancy."
+  :line 2
+  :lib cloverage.sample.dummy-sample
   :file "cloverage/sample/dummy_sample.clj"}
  {:text
-  "  It allows us to check whether regexs in combination with path parameters work.\")",
-  :line 3,
-  :lib cloverage.sample.dummy-sample,
+  "  It allows us to check whether regexs in combination with path parameters work.\")"
+  :line 3
+  :lib cloverage.sample.dummy-sample
   :file "cloverage/sample/dummy_sample.clj"}
- {:text "",
-  :line 4,
-  :lib cloverage.sample.dummy-sample,
+ {:text ""
+  :line 4
+  :lib cloverage.sample.dummy-sample
   :file "cloverage/sample/dummy_sample.clj"}
- {:text "(defn dummy-function",
-  :line 5,
-  :lib cloverage.sample.dummy-sample,
-  :file "cloverage/sample/dummy_sample.clj",
+ {:text "(defn dummy-function"
+  :line 5
+  :lib cloverage.sample.dummy-sample
+  :file "cloverage/sample/dummy_sample.clj"
   :form
   (def
     dummy-function
@@ -38,7 +38,7 @@
        (cloverage.instrument/wrapm
         cloverage.coverage/track-coverage
         5
-        (println "Hello, World!"))))),
+        (println "Hello, World!")))))
   :full-form
   (def
     dummy-function
@@ -47,19 +47,19 @@
        (cloverage.instrument/wrapm
         cloverage.coverage/track-coverage
         5
-        (println "Hello, World!"))))),
-  :tracked true,
-  :covered true,
+        (println "Hello, World!")))))
+  :tracked true
+  :covered true
   :hits 1}
- {:text "  [& args]",
-  :line 6,
-  :lib cloverage.sample.dummy-sample,
+ {:text "  [& args]"
+  :line 6
+  :lib cloverage.sample.dummy-sample
   :file "cloverage/sample/dummy_sample.clj"}
- {:text "  (println \"Hello, World!\"))",
-  :line 7,
-  :lib cloverage.sample.dummy-sample,
-  :file "cloverage/sample/dummy_sample.clj",
-  :form (println "Hello, World!"),
+ {:text "  (println \"Hello, World!\"))"
+  :line 7
+  :lib cloverage.sample.dummy-sample
+  :file "cloverage/sample/dummy_sample.clj"
+  :form (println "Hello, World!")
   :full-form
   ((cloverage.instrument/wrapm
     cloverage.coverage/track-coverage
@@ -68,19 +68,19 @@
    (cloverage.instrument/wrapm
     cloverage.coverage/track-coverage
     7
-    "Hello, World!")),
+    "Hello, World!"))
   :tracked true}
- {:text "  (println \"Hello, World!\"))",
-  :line 7,
-  :lib cloverage.sample.dummy-sample,
-  :file "cloverage/sample/dummy_sample.clj",
-  :form println,
-  :full-form println,
+ {:text "  (println \"Hello, World!\"))"
+  :line 7
+  :lib cloverage.sample.dummy-sample
+  :file "cloverage/sample/dummy_sample.clj"
+  :form println
+  :full-form println
   :tracked true}
- {:text "  (println \"Hello, World!\"))",
-  :line 7,
-  :lib cloverage.sample.dummy-sample,
-  :file "cloverage/sample/dummy_sample.clj",
-  :form "Hello, World!",
-  :full-form "Hello, World!",
+ {:text "  (println \"Hello, World!\"))"
+  :line 7
+  :lib cloverage.sample.dummy-sample
+  :file "cloverage/sample/dummy_sample.clj"
+  :form "Hello, World!"
+  :full-form "Hello, World!"
   :tracked true})

--- a/cloverage/test/cloverage/source_test.clj
+++ b/cloverage/test/cloverage/source_test.clj
@@ -3,15 +3,14 @@
             [clojure.test :as t]))
 
 (t/deftest multibyte-test
-  "Regression test for a bug where the form reader fails to read files
-  containing multibyte chars."
-  (t/is (= (sut/forms 'cloverage.sample.multibyte-sample)
-           '((ns cloverage.sample.multibyte-sample)
-             (def a "あ")))))
+  (t/testing "Form reader reads files with multibyte chars"
+    (t/is (= (sut/forms 'cloverage.sample.multibyte-sample)
+             '((ns cloverage.sample.multibyte-sample)
+               (def a "あ"))))))
 
 (t/deftest form-reader-test
-  "Useful exception is thrown if resource-path not found for a ns"
-  (with-redefs [sut/resource-path (constantly nil)]
-    (t/is (thrown-with-msg? clojure.lang.ExceptionInfo
-                            #"Resource path not found for namespace: foo.bar"
-                            (sut/form-reader 'foo.bar)))))
+  (t/testing "Useful exception is thrown if resource-path not found for a ns"
+    (with-redefs [sut/resource-path (constantly nil)]
+      (t/is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #"Resource path not found for namespace: foo.bar"
+                              (sut/form-reader 'foo.bar))))))

--- a/lein-cloverage/project.clj
+++ b/lein-cloverage/project.clj
@@ -15,5 +15,7 @@
                  :deploy-via :clojars}
   :deploy-repositories [["clojars" {:username :env/clojars_username :password :env/clojars_password :sign-releases false}]]
   :min-lein-version "2.0.0"
-  :profiles {:dev {:plugins [[lein-cljfmt "0.5.6"]]}}
+  :profiles {:dev {:plugins [[lein-cljfmt "0.5.7"]
+                             [jonase/eastwood "0.2.5"]
+                             [lein-kibit "0.1.6"]]}}
   :eval-in-leiningen true)


### PR DESCRIPTION
This PR re-applies the reverted fix for #143, and includes additional changes to get the CircleCI builds to pass (was entirely a matter of configuration in `.circleci/config.yml`).

With this merged you will have the following in Travis CI and CircleCI:
 - test
 - cljfmt
 - eastwood
 - kibit

All running successfully.
