### PR TITLE
Read options from the Leiningen project file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ in github. Commentary on the change should appear as a nested, unordered list.
 
 - Bugfixes
   - Fix the handling of --ns-regex and --test-ns-regex (#183)
+  - Read options from the Leiningen project file (#155) 
 
 ## 1.0.10
 - Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ in github. Commentary on the change should appear as a nested, unordered list.
 
 - Bugfixes
   - Fix the handling of --ns-regex and --test-ns-regex (#183)
-  - Read options from the Leiningen project file (#155) 
+  - Read options from the Leiningen project file (#155)
 
 ## 1.0.10
 - Improvements

--- a/README.md
+++ b/README.md
@@ -26,6 +26,41 @@ to desired value, for example `CLOVERAGE_VERSION=1.0.4-SNAPSHOT lein cloverage`
 
 By default, the plugin will use the latest release version of cloverage.
 
+#### Leiningen project options
+You can set project default settings for Cloverage in your
+project. Command line arguments can still be used and will be merged
+in. List options are merged by concatenation, for other options the
+project value is used.
+
+Available options and command-line arguments:
+```
+ Project           Switches                     Default          Desc
+ -------           --------                     -------          ----
+ :output           -o, --output                 target/coverage  Output directory.
+ :text?            --no-text, --text            false            Produce a text report.
+ :html?            --no-html, --html            true             Produce an HTML report.
+ :emma-xml?        --no-emma-xml, --emma-xml    false            Produce an EMMA XML report. [emma.sourceforge.net]
+ :lcov?            --no-lcov, --lcov            false            Produce a lcov/gcov report.
+ :codecov?         --no-codecov, --codecov      false            Generate a JSON report for Codecov.io
+ :coveralls?       --no-coveralls, --coveralls  false            Send a JSON report to Coveralls if on a CI server
+ :junit?           --no-junit, --junit          false            Output test results as junit xml file. Supported in :clojure.test runner
+ :raw?             --no-raw, --raw              false            Output raw coverage data (for debugging).
+ :summary?         --no-summary, --summary      true             Prints a summary
+ :fail-threshold   --fail-threshold             0                Sets the percentage threshold at which cloverage will abort the build. Default: 0%
+ :low-watermark    --low-watermark              50               Sets the low watermark percentage (valid values 0..100). Default: 50%
+ :high-watermark   --high-watermark             80               Sets the high watermark percentage (valid values 0..100). Default: 80%
+ :debug?           -d, --no-debug, --debug      false            Output debugging information to stdout.
+ :runner           -r, --runner                 :clojure.test    Specify which test runner to use. Built-in runners are `clojure.test` and `midje`.
+ :nop?             --no-nop, --nop              false            Instrument with noops.
+ :ns-regex         -n, --ns-regex               []               Regex for instrumented namespaces (can be repeated).
+ :ns-exclude-regex -e, --ns-exclude-regex       []               Regex for namespaces not to be instrumented (can be repeated).
+ :test-ns-regex    -t, --test-ns-regex          []               Regex for test namespaces (can be repeated).
+ :src-ns-path      -p, --src-ns-path            []               Path (string) to directory containing source code namespaces (can be repeated).
+ :test-ns-path     -s, --test-ns-path           []               Path (string) to directory containing test namespaces (can be repeated).
+ :extra-test-ns    -x, --extra-test-ns          []               Additional test namespace (string) to add (can be repeated).
+ :help?            -h, --no-help, --help        false            Show help.
+```
+
 ### mvn
 
 There is no maven plugin right now. A workaround is to import this library in the
@@ -82,4 +117,3 @@ Distributed under the Eclipse Public License, the same as Clojure.
 Some code was taken from
 * Java IO interop (clojure-contrib/duck-streams) by Stuart Sierra (see cloverage/source.clj)
 * Topological sort (https://gist.github.com/1263783) by Alan Dipert (see cloverage/kahn.clj)
-

--- a/cloverage/project.clj
+++ b/cloverage/project.clj
@@ -2,40 +2,40 @@
   :description "Form-level test coverage for clojure."
   :url "https://www.github.com/cloverage/cloverage"
   :scm {:name "git"
-        :dir  ".."
-        :url  "https://www.github.com/cloverage/cloverage"
-        :tag  "HEAD"}
+          :dir  ".."
+          :url  "https://www.github.com/cloverage/cloverage"
+          :tag  "HEAD"}
   :vcs :git
   :main ^:skip-aot cloverage.coverage
   :aot [clojure.tools.reader]
   :license {:name "Eclipse Public License - v 1.0"
-            :url "http://www.eclipse.org/legal/epl-v10.html"
-            :distribution :repo
-            :comments "same as Clojure"}
+          :url "http://www.eclipse.org/legal/epl-v10.html"
+          :distribution :repo
+          :comments "same as Clojure"}
   :deploy-repositories [["clojars" {:username :env/clojars_username :password :env/clojars_password :sign-releases false}]]
   :plugins [[lein-release "1.0.9"]]
   :lein-release {:scm :git ; Because we're not in the top-level directory, so it doesn't auto-detect
-                 :deploy-via :clojars}
+                    :deploy-via :clojars}
   :dependencies [[org.clojure/tools.reader "1.1.2"]
-                 [org.clojure/tools.cli "0.3.5"]
-                 [org.clojure/tools.logging "0.4.0"]
-                 [org.clojure/data.xml "0.0.8"]
-                 [org.clojure/data.json "0.2.6"]
-                 [bultitude "0.2.8"]
-                 [riddley "0.1.14"]
-                 [slingshot "0.12.2"]]
+                    [org.clojure/tools.cli "0.3.5"]
+                    [org.clojure/tools.logging "0.4.0"]
+                    [org.clojure/data.xml "0.0.8"]
+                    [org.clojure/data.json "0.2.6"]
+                    [bultitude "0.2.8"]
+                    [riddley "0.1.14"]
+                    [slingshot "0.12.2"]]
   :profiles {:dev    {:aot          ^:replace []
-                      :dependencies [[org.clojure/clojure "1.8.0"]]
-                      :plugins [[lein-cljfmt "0.5.7"]
-                                [jonase/eastwood "0.2.5"]
-                                [lein-kibit "0.1.6"]]
-                      :eastwood {:exclude-linters [:no-ns-form-found]}
-                      :global-vars {*warn-on-reflection* true}}
-             :sample {:source-paths ["sample"]}
-             :1.4    {:dependencies [[org.clojure/clojure "1.4.0"]]}
-             :1.5    {:dependencies [[org.clojure/clojure "1.5.1"]]}
-             :1.6    {:dependencies [[org.clojure/clojure "1.6.0"]]}
-             :1.7    {:dependencies [[org.clojure/clojure "1.7.0"]]}
-             :1.8    {:dependencies [[org.clojure/clojure "1.8.0"]]}
-             :master {:dependencies [[org.clojure/clojure "1.9.0-master-SNAPSHOT"]]}}
+                    :dependencies [[org.clojure/clojure "1.8.0"]]
+                    :plugins [[lein-cljfmt "0.5.7"]
+                              [jonase/eastwood "0.2.5"]
+                              [lein-kibit "0.1.6"]]
+                    :eastwood {:exclude-linters [:no-ns-form-found]}
+                    :global-vars {*warn-on-reflection* true}}
+          :sample {:source-paths ["sample"]}
+          :1.4    {:dependencies [[org.clojure/clojure "1.4.0"]]}
+          :1.5    {:dependencies [[org.clojure/clojure "1.5.1"]]}
+          :1.6    {:dependencies [[org.clojure/clojure "1.6.0"]]}
+          :1.7    {:dependencies [[org.clojure/clojure "1.7.0"]]}
+          :1.8    {:dependencies [[org.clojure/clojure "1.8.0"]]}
+          :master {:dependencies [[org.clojure/clojure "1.9.0-master-SNAPSHOT"]]}}
   :aliases {"all" ["with-profile" "+1.4:+1.5:+1.6:+1.7:+1.8:+master"]})

--- a/cloverage/src/cloverage/args.clj
+++ b/cloverage/src/cloverage/args.clj
@@ -152,33 +152,3 @@
 (defn parse-args [args project-settings]
   (-> (apply cli/cli args arguments)
       (fix-opts project-settings)))
-
-(comment
-  "Functions copied from cli tools and modified to add in the project "
-  (defn- build-doc [{:keys [project switches docs default]}]
-    [project
-     (apply str (interpose ", " switches))
-     (or (str default) "")
-     (or docs "")])
-
-  (defn- banner-for [specs]
-    (let [docs     (into (map build-doc specs)
-                         [["-------" "--------" "-------" "----"]
-                          ["Project" "Switches" "Default" "Desc"]])
-          max-cols (->> (for [d docs] (map (comp count str) d))
-                        (apply map (fn [& c] (apply vector c)))
-                        (map #(apply max %)))
-          vs       (for [d docs]
-                     (mapcat (fn [& x] (apply vector x)) max-cols d))]
-      (doseq [v vs]
-        (clojure.pprint/cl-format true "~{ ~vA ~vA  ~vA  ~vA ~}" v)
-        (prn))))
-
-  ;; to generate the output for the README:
-
-  (->> arguments
-       (map #'cli/generate-spec)
-       (map (fn [{:keys [name] :as opt}]
-              (-> opt
-                  (assoc :project (get boolean-flags name name)))))
-       banner-for))

--- a/cloverage/src/cloverage/args.clj
+++ b/cloverage/src/cloverage/args.clj
@@ -152,3 +152,33 @@
 (defn parse-args [args project-settings]
   (-> (apply cli/cli args arguments)
       (fix-opts project-settings)))
+
+(comment
+  "Functions copied from cli tools and modified to add in the project "
+  (defn- build-doc [{:keys [project switches docs default]}]
+    [project
+     (apply str (interpose ", " switches))
+     (or (str default) "")
+     (or docs "")])
+
+  (defn- banner-for [specs]
+    (let [docs     (into (map build-doc specs)
+                         [["-------" "--------" "-------" "----"]
+                          ["Project" "Switches" "Default" "Desc"]])
+          max-cols (->> (for [d docs] (map (comp count str) d))
+                        (apply map (fn [& c] (apply vector c)))
+                        (map #(apply max %)))
+          vs       (for [d docs]
+                     (mapcat (fn [& x] (apply vector x)) max-cols d))]
+      (doseq [v vs]
+        (clojure.pprint/cl-format true "~{ ~vA ~vA  ~vA  ~vA ~}" v)
+        (prn))))
+
+  ;; to generate the output for the README:
+
+  (->> arguments
+       (map #'cli/generate-spec)
+       (map (fn [{:keys [name] :as opt}]
+              (-> opt
+                  (assoc :project (get boolean-flags name name)))))
+       banner-for))

--- a/cloverage/src/cloverage/args.clj
+++ b/cloverage/src/cloverage/args.clj
@@ -1,0 +1,154 @@
+(ns cloverage.args
+  (:refer-clojure :exclude [boolean?])
+  (:require [clojure.tools.cli :as cli]
+            [clojure.set :as set])
+  (:import (java.util.regex Pattern)))
+
+(defn- boolean? [x]
+  (instance? Boolean x))
+
+(defn- regexes-or-strings?
+  [coll]
+  (->> coll
+       (every? #(or (string? %)
+                    (instance? Pattern %)))))
+
+(def valid
+  {:text?            boolean?
+   :html?            boolean?
+   :raw?             boolean?
+   :emma-xml?        boolean?
+   :junit?           boolean?
+   :lcov?            boolean?
+   :codecov?         boolean?
+   :coveralls?       boolean?
+   :summary?         boolean?
+   :fail-threshold   integer?
+   :low-watermark    integer?
+   :high-watermark   integer?
+   :debug?           boolean?
+   :nop?             boolean?
+   :extra-test-ns    regexes-or-strings?
+   :help?            boolean?
+   :ns-regex         regexes-or-strings?
+   :test-ns-regex    regexes-or-strings?
+   :ns-exclude-regex regexes-or-strings?
+   :src-ns-path      regexes-or-strings?
+   :runner           keyword?
+   :test-ns-path     regexes-or-strings?})
+
+(defn valid? [[k v :as pair]]
+  (let [f (get valid k (constantly true))]
+    (if (f v)
+      pair
+      (println "Invalid value:" k ", " v))))
+
+(defn- collecting-args-parser []
+  (let [col (atom [])]
+    (fn [val]
+      (swap! col conj val))))
+
+(defn- parse-kw-str [s]
+  (let [s (name s)
+        s (if (and s (.startsWith s ":")) (subs s 1) s)]
+    (keyword s)))
+
+(def boolean-flags
+  (letfn [(add-? [k]
+            [k (keyword (str (name k) \?))])]
+    (->> [:text :html :raw :emma-xml :junit :lcov :codecov :coveralls :summary :debug :nop :help]
+         (map add-?)
+         (into {}))))
+
+(defn- overwrite
+  "For each key-value pair in project settings, overwrite the value in opts"
+  [opts project-settings]
+  (->> project-settings
+       (keep valid?)
+       (reduce (fn [o [k v]]
+                 (if (coll? v)
+                   (update o k concat v)
+                   (assoc o k v)))
+               opts)))
+
+(defn- fix-opts
+  "Clean the parsed command-line options.
+  Rename boolean flags then merge in any project settings."
+  [[opts add-nses help] project-settings]
+  (let [->regexes (partial map re-pattern)
+        opts      (-> opts
+                      (update :ns-regex ->regexes)
+                      (update :test-ns-regex ->regexes)
+                      (update :ns-exclude-regex ->regexes)
+                      (set/rename-keys boolean-flags)
+                      (overwrite project-settings))]
+    [opts add-nses help]))
+
+(def arguments
+  [["-o" "--output" "Output directory." :default "target/coverage"]
+   ["--[no-]text"
+    "Produce a text report." :default false]
+   ["--[no-]html"
+    "Produce an HTML report." :default true]
+   ["--[no-]emma-xml"
+    "Produce an EMMA XML report. [emma.sourceforge.net]" :default false]
+   ["--[no-]lcov"
+    "Produce a lcov/gcov report." :default false]
+   ["--[no-]codecov"
+    "Generate a JSON report for Codecov.io" :default false]
+   ["--[no-]coveralls"
+    "Send a JSON report to Coveralls if on a CI server" :default false]
+   ["--[no-]junit"
+    "Output test results as junit xml file. Supported in :clojure.test runner" :default false]
+   ["--[no-]raw"
+    "Output raw coverage data (for debugging)." :default false]
+   ["--[no-]summary"
+    "Prints a summary" :default true]
+   ["--fail-threshold"
+    "Sets the percentage threshold at which cloverage will abort the build. Default: 0%"
+    :default 0
+    :parse-fn #(Integer/parseInt %)]
+   ["--low-watermark"
+    "Sets the low watermark percentage (valid values 0..100). Default: 50%"
+    :default 50
+    :parse-fn #(Integer/parseInt %)]
+   ["--high-watermark"
+    "Sets the high watermark percentage (valid values 0..100). Default: 80%"
+    :default 80
+    :parse-fn #(Integer/parseInt %)]
+   ["-d" "--[no-]debug"
+    "Output debugging information to stdout." :default false]
+   ["-r" "--runner"
+    "Specify which test runner to use. Built-in runners are `clojure.test` and `midje`."
+    :default :clojure.test
+    :parse-fn parse-kw-str]
+   ["--[no-]nop" "Instrument with noops." :default false]
+   ["-n" "--ns-regex"
+    "Regex for instrumented namespaces (can be repeated)."
+    :default []
+    :parse-fn (collecting-args-parser)]
+   ["-e" "--ns-exclude-regex"
+    "Regex for namespaces not to be instrumented (can be repeated)."
+    :default []
+    :parse-fn (collecting-args-parser)]
+   ["-t" "--test-ns-regex"
+    "Regex for test namespaces (can be repeated)."
+    :default []
+    :parse-fn (collecting-args-parser)]
+   ["-p" "--src-ns-path"
+    "Path (string) to directory containing source code namespaces (can be repeated)."
+    :default []
+    :parse-fn (collecting-args-parser)]
+   ["-s" "--test-ns-path"
+    "Path (string) to directory containing test namespaces (can be repeated)."
+    :default []
+    :parse-fn (collecting-args-parser)]
+   ["-x" "--extra-test-ns"
+    "Additional test namespace (string) to add (can be repeated)."
+    :default []
+    :parse-fn (collecting-args-parser)]
+   ["-h" "--help" "Show help." :default false :flag true]])
+
+(defn parse-args [args project-settings]
+  (-> (apply cli/cli args arguments)
+      (fix-opts project-settings)))

--- a/cloverage/src/cloverage/args.clj
+++ b/cloverage/src/cloverage/args.clj
@@ -9,9 +9,8 @@
 
 (defn- regexes-or-strings?
   [coll]
-  (->> coll
-       (every? #(or (string? %)
-                    (instance? Pattern %)))))
+  (every? #(or (string? %)
+               (instance? Pattern %)) coll))
 
 (def valid
   {:text?            boolean?
@@ -150,5 +149,4 @@
    ["-h" "--help" "Show help." :default false :flag true]])
 
 (defn parse-args [args project-settings]
-  (-> (apply cli/cli args arguments)
-      (fix-opts project-settings)))
+  (fix-opts (apply cli/cli args arguments) project-settings))

--- a/cloverage/src/cloverage/coverage.clj
+++ b/cloverage/src/cloverage/coverage.clj
@@ -261,7 +261,6 @@
                 ns-regex
                 test-ns-regex
                 ns-exclude-regex
-                ns-paths
                 src-ns-path
                 runner
                 test-ns-path]} opts

--- a/cloverage/src/cloverage/coverage.clj
+++ b/cloverage/src/cloverage/coverage.clj
@@ -89,8 +89,7 @@
 (defn remove-nses
   [namespaces regex-patterns]
   (debug/tprn "Removing" regex-patterns)
-  (let [v (->> namespaces
-               (remove (fn [ns] (some #(re-matches % ns) regex-patterns))))]
+  (let [v (remove (fn [ns] (some #(re-matches % ns) regex-patterns)) namespaces)]
     (debug/tprn "Out: " v)
     v))
 

--- a/cloverage/src/cloverage/coverage.clj
+++ b/cloverage/src/cloverage/coverage.clj
@@ -2,11 +2,10 @@
   (:gen-class)
   (:require [bultitude.core :as blt]
             [clojure.java.io :as io]
-            [clojure.set :as set]
             [clojure.test :as test]
-            [clojure.tools.cli :as cli]
             [clojure.test.junit :as junit]
             [clojure.tools.logging :as log]
+            [cloverage.args :as args]
             [cloverage.debug :as debug]
             [cloverage.dependency :as dep]
             [cloverage.instrument :as inst]
@@ -20,7 +19,8 @@
             [cloverage.report.raw :as raw]
             [cloverage.report.text :as text]
             [cloverage.source :as src])
-  (:import clojure.lang.IObj))
+  (:import (java.io FileNotFoundException)
+           (clojure.lang IObj)))
 
 (def ^:dynamic *instrumented-ns*) ;; currently instrumented ns
 (def ^:dynamic *covered* (atom []))
@@ -56,16 +56,16 @@
   "Adds a structure representing the given form to the *covered* vector."
   [form line-hint]
   (debug/tprnl "Adding form" form "at line" (:line (meta form)) "hint" line-hint)
-  (let [lib  *instrumented-ns*
-        file (src/resource-path lib)
-        line (or (:line (meta form)) line-hint)
-        form-info {:form (or (:original (meta form))
-                             form)
+  (let [lib       *instrumented-ns*
+        file      (src/resource-path lib)
+        line      (or (:line (meta form)) line-hint)
+        form-info {:form      (or (:original (meta form))
+                                  form)
                    :full-form form
-                   :tracked true
-                   :line line
-                   :lib  lib
-                   :file file}]
+                   :tracked   true
+                   :line      line
+                   :lib       lib
+                   :file      file}]
     (binding [*print-meta* true]
       (debug/tprn "Parsed form" form)
       (debug/tprn "Adding" form-info))
@@ -77,90 +77,22 @@
 (defn track-coverage [line-hint form]
   (debug/tprnl "Track coverage called with" form)
   (let [idx   (count @*covered*)
-        form' (if (instance? clojure.lang.IObj form)
+        form' (if (instance? IObj form)
                 (vary-meta form assoc :idx idx)
                 form)]
     `(capture ~(add-form form' line-hint) ~form')))
 
-(defn collecting-args-parser []
-  (let [col (atom [])]
-    (fn [val]
-      (swap! col conj val))))
-
-(defn- parse-kw-str [s]
-  (let [s (name s)
-        s (if (and s (.startsWith s ":")) (subs s 1) s)]
-    (keyword s)))
-
-(defn parse-args [args]
-  (cli/cli args
-           ["-o" "--output" "Output directory." :default "target/coverage"]
-           ["--[no-]text"
-            "Produce a text report." :default false]
-           ["--[no-]html"
-            "Produce an HTML report." :default true]
-           ["--[no-]emma-xml"
-            "Produce an EMMA XML report. [emma.sourceforge.net]" :default false]
-           ["--[no-]lcov"
-            "Produce a lcov/gcov report." :default false]
-           ["--[no-]codecov"
-            "Generate a JSON report for Codecov.io" :default false]
-           ["--[no-]coveralls"
-            "Send a JSON report to Coveralls if on a CI server" :default false]
-           ["--[no-]junit"
-            "Output test results as junit xml file. Supported in :clojure.test runner" :default false]
-           ["--[no-]raw"
-            "Output raw coverage data (for debugging)." :default false]
-           ["--[no-]summary"
-            "Prints a summary" :default true]
-           ["--fail-threshold"
-            "Sets the percentage threshold at which cloverage will abort the build. Default: 0%"
-            :default 0
-            :parse-fn #(Integer/parseInt %)]
-           ["--low-watermark"
-            "Sets the low watermark percentage (valid values 0..100). Default: 50%"
-            :default 50
-            :parse-fn #(Integer/parseInt %)]
-           ["--high-watermark"
-            "Sets the high watermark percentage (valid values 0..100). Default: 80%"
-            :default 80
-            :parse-fn #(Integer/parseInt %)]
-           ["-d" "--[no-]debug"
-            "Output debugging information to stdout." :default false]
-           ["-r" "--runner"
-            "Specify which test runner to use. Built-in runners are `clojure.test` and `midje`."
-            :default :clojure.test
-            :parse-fn parse-kw-str]
-           ["--[no-]nop" "Instrument with noops." :default false]
-           ["-n" "--ns-regex"
-            "Regex for instrumented namespaces (can be repeated)."
-            :default  []
-            :parse-fn (collecting-args-parser)]
-           ["-e" "--ns-exclude-regex"
-            "Regex for namespaces not to be instrumented (can be repeated)."
-            :default  []
-            :parse-fn (collecting-args-parser)]
-           ["-t" "--test-ns-regex"
-            "Regex for test namespaces (can be repeated)."
-            :default []
-            :parse-fn (collecting-args-parser)]
-           ["-p" "--src-ns-path"
-            "Path (string) to directory containing source code namespaces (can be repeated)."
-            :default []
-            :parse-fn (collecting-args-parser)]
-           ["-s" "--test-ns-path"
-            "Path (string) to directory containing test namespaces (can be repeated)."
-            :default []
-            :parse-fn (collecting-args-parser)]
-           ["-x" "--extra-test-ns"
-            "Additional test namespace (string) to add (can be repeated)."
-            :default  []
-            :parse-fn (collecting-args-parser)]
-           ["-h" "--help" "Show help." :default false :flag true]))
-
 (defn mark-loaded [namespace]
   (binding [*ns* (find-ns 'clojure.core)]
     (eval `(dosync (alter clojure.core/*loaded-libs* conj '~namespace)))))
+
+(defn remove-nses
+  [namespaces regex-patterns]
+  (debug/tprn "Removing" regex-patterns)
+  (let [v (->> namespaces
+               (remove (fn [ns] (some #(re-matches % ns) regex-patterns))))]
+    (debug/tprn "Out: " v)
+    v))
 
 (defn find-nses
   "Given ns-paths and regex-patterns returns:
@@ -169,11 +101,16 @@
   * all namespaces on the classpath that match any of the regex-patterns (if ns-paths is empty)
   * namespaces on ns-paths that match any of the regex-patterns"
   [ns-paths regex-patterns]
+  (debug/tprn "find:" {:ns-paths       ns-paths
+                       :regex-patterns regex-patterns})
   (let [namespaces (map name
                         (cond
                           (and (empty? ns-paths) (empty? regex-patterns)) '()
                           (empty? ns-paths) (blt/namespaces-on-classpath)
                           :else (mapcat #(blt/namespaces-on-classpath :classpath %) ns-paths)))]
+    (debug/tprn "found:" {:namespaces     namespaces
+                          :ns-paths       ns-paths
+                          :regex-patterns regex-patterns})
     (if (seq regex-patterns)
       (filter (fn [ns] (some #(re-matches % ns) regex-patterns)) namespaces)
       namespaces)))
@@ -214,111 +151,107 @@
 (defn- coverage-under? [forms failure-threshold]
   (when (pos? failure-threshold)
     (let [pct-covered (apply min (vals (rep/total-stats forms)))
-          failed? (< pct-covered failure-threshold)]
+          failed?     (< pct-covered failure-threshold)]
       (when failed?
         (println "Failing build as coverage is below threshold of" failure-threshold "%"))
       failed?)))
 
-(def boolean-flags
-  (letfn [(add-? [k]
-            [k (keyword (str (name k) \?))])]
-    (->> [:text :html :raw :emma-xml :junit :lcov :codecov :coveralls :summary :debug :nop :help]
-         (map add-?)
-         (into {}))))
+(defn run-main
+  [[{:keys [debug?] :as opts} add-nses help]]
+  (binding [*ns*          (find-ns 'cloverage.coverage)
+            debug/*debug* debug?]
+    (let [^String output (:output opts)
+          {:keys [text?
+                  html?
+                  raw?
+                  emma-xml?
+                  junit?
+                  lcov?
+                  codecov?
+                  coveralls?
+                  summary?
+                  fail-threshold
+                  low-watermark
+                  high-watermark
+                  nop?
+                  extra-test-ns
+                  help?
+                  ns-regex
+                  test-ns-regex
+                  ns-exclude-regex
+                  src-ns-path
+                  runner
+                  test-ns-path]} opts
+          include        (-> src-ns-path
+                             (find-nses ns-regex)
+                             (remove-nses ns-exclude-regex))
+          namespaces     (concat add-nses include)
+          test-nses      (concat extra-test-ns (find-nses test-ns-path test-ns-regex))
+          ordered-nses   (dep/in-dependency-order (map symbol namespaces))]
+      (if help?
+        (println help)
+        (do
+          (println "Loading namespaces: " (apply list namespaces))
+          (println "Test namespaces: " test-nses)
 
-(defn- fix-opts
-  "Clean the options map."
-  [opts]
-  (let [->regexes (partial map re-pattern)]
-    (-> opts
-        (update :ns-regex ->regexes)
-        (update :test-ns-regex ->regexes)
-        (update :ns-exclude-regex ->regexes)
-        (set/rename-keys boolean-flags))))
+          (if (empty? ordered-nses)
+            (throw (RuntimeException. "Cannot instrument namespaces; there is a cyclic dependency"))
+            (doseq [namespace ordered-nses]
+              (binding [*instrumented-ns* namespace]
+                (if nop?
+                  (inst/instrument #'inst/nop namespace)
+                  (inst/instrument #'track-coverage namespace)))
+              (println "Loaded " namespace " .")
+              ;; mark the ns as loaded
+              (mark-loaded namespace)))
+
+          (println "Instrumented namespaces.")
+          ;; load runner multimethod definition from other dependencies
+          (when-not (#{:clojure.test :midje} runner)
+            (try (require (symbol (format "%s.cloverage" (name runner))))
+                 (catch FileNotFoundException _)))
+          (let [test-result (when (seq test-nses)
+                              (if (and junit? (not= runner :clojure.test))
+                                (throw (RuntimeException.
+                                        "Junit output only supported for clojure.test at present"))
+                                ((runner-fn opts) (map symbol test-nses))))
+                forms       (rep/gather-stats @*covered*)
+                ;; sum up errors as in lein test
+                errors      (when test-result
+                              (:errors test-result))
+                exit-code   (cond
+                              (not test-result) -1
+                              (> errors 128) -2
+                              (coverage-under? forms fail-threshold) -3
+                              :else errors)]
+            (println "Ran tests.")
+            (when output
+              (.mkdirs (io/file output))
+              (when text? (text/report output forms))
+              (when html? (html/report output forms))
+              (when emma-xml? (emma-xml/report output forms))
+              (when lcov? (lcov/report output forms))
+              (when raw? (raw/report output forms @*covered*))
+              (when codecov? (codecov/report output forms))
+              (when coveralls? (coveralls/report output forms))
+              (when summary? (console/summary forms low-watermark high-watermark)))
+            (if *exit-after-test*
+              (do (shutdown-agents)
+                  (System/exit exit-code))
+              exit-code)))))))
+
+(defn run-project [project-opts & args]
+  (try
+    (-> args
+        (args/parse-args project-opts)
+        (run-main))
+    (catch Exception e
+      (.printStackTrace e)
+      (throw e))))
 
 (defn -main
   "Produce test coverage report for some namespaces"
   [& args]
-  (let [[opts add-nses help] (parse-args args)
-        ^String output  (:output opts)
-        opts (fix-opts opts)
-        {:keys [text?
-                html?
-                raw?
-                emma-xml?
-                junit?
-                lcov?
-                codecov?
-                coveralls?
-                summary?
-                fail-threshold
-                low-watermark
-                high-watermark
-                debug?
-                nop?
-                extra-test-ns
-                help?
-                ns-regex
-                test-ns-regex
-                ns-exclude-regex
-                src-ns-path
-                runner
-                test-ns-path]} opts
-        namespaces      (set/difference
-                         (set (concat add-nses (find-nses src-ns-path ns-regex)))
-                         (set (find-nses src-ns-path ns-exclude-regex)))
-        test-nses       (concat extra-test-ns (find-nses test-ns-path test-ns-regex))
-        ordered-nses    (dep/in-dependency-order (map symbol namespaces))]
-    (if help?
-      (println help)
-      (binding [*ns*      (find-ns 'cloverage.coverage)
-                debug/*debug*   debug?]
-
-        (println "Loading namespaces: " (apply list namespaces))
-        (println "Test namespaces: " test-nses)
-
-        (if (empty? ordered-nses)
-          (throw (RuntimeException. "Cannot instrument namespaces; there is a cyclic dependency"))
-          (doseq [namespace ordered-nses]
-            (binding [*instrumented-ns* namespace]
-              (if nop?
-                (inst/instrument #'inst/nop namespace)
-                (inst/instrument #'track-coverage namespace)))
-            (println "Loaded " namespace " .")
-            ;; mark the ns as loaded
-            (mark-loaded namespace)))
-
-        (println "Instrumented namespaces.")
-        ;; load runner multimethod definition from other dependencies
-        (when-not (#{:clojure.test :midje} runner)
-          (try (require (symbol (format "%s.cloverage" (name runner))))
-               (catch java.io.FileNotFoundException _)))
-        (let [test-result (when (seq test-nses)
-                            (if (and junit? (not= runner :clojure.test))
-                              (throw (RuntimeException.
-                                      "Junit output only supported for clojure.test at present"))
-                              ((runner-fn opts) (map symbol test-nses))))
-              forms       (rep/gather-stats @*covered*)
-              ;; sum up errors as in lein test
-              errors      (when test-result
-                            (:errors test-result))
-              exit-code   (cond
-                            (not test-result) -1
-                            (> errors 128)    -2
-                            (coverage-under? forms fail-threshold) -3
-                            :else             errors)]
-          (println "Ran tests.")
-          (when output
-            (.mkdirs (io/file output))
-            (when text? (text/report output forms))
-            (when html? (html/report output forms))
-            (when emma-xml? (emma-xml/report output forms))
-            (when lcov? (lcov/report output forms))
-            (when raw? (raw/report output forms @*covered*))
-            (when codecov? (codecov/report output forms))
-            (when coveralls? (coveralls/report output forms))
-            (when summary? (console/summary forms low-watermark high-watermark)))
-          (if *exit-after-test*
-            (do (shutdown-agents)
-                (System/exit exit-code))
-            exit-code))))))
+  (-> args
+      (args/parse-args {})
+      (run-main)))

--- a/cloverage/src/cloverage/dependency.clj
+++ b/cloverage/src/cloverage/dependency.clj
@@ -51,19 +51,19 @@
 
 (defn dependency-libs
   "Given a (ns ...) form, return the ns name and a list of namespaces
-   it depends on."
+  it depends on."
   [[ns-sym ns-nam & refs]]
   [ns-nam (set (mapcat ref-dependencies refs))])
 
 (defn dependency-sort
   "Given a list of [ns-name dependencies] pairs, return a topological
-   sort of the dependency graph."
+  sort of the dependency graph."
   [dep-lists]
   (let [dep-graph (into {} dep-lists)]
     (reverse (filter (set (keys dep-graph)) (kahn-sort dep-graph)))))
 
 (defn in-dependency-order
   "Sort a list of namespace symbols so that any namespace occurs after
-   its dependencies."
+  its dependencies."
   [nses]
   (dependency-sort (map #(-> % ns-form dependency-libs) nses)))

--- a/cloverage/src/cloverage/instrument.clj
+++ b/cloverage/src/cloverage/instrument.clj
@@ -18,12 +18,12 @@
 
 (defn propagate-line-numbers
   "Assign :line metadata to all possible elements in a form,
-   using start as default."
+  using start as default."
   [start form]
   (if (iobj? form)
     (let [line (or (:line (meta form)) start)
           recs (if (and (seq? form) (seq form))
-                 ;; (seq '()) gives nil which makes us NPE. Bad.
+                ;; (seq '()) gives nil which makes us NPE. Bad.
                  (with-meta
                    (seq (map (partial propagate-line-numbers line) form))
                    (meta form))
@@ -134,7 +134,7 @@
 
 (defmulti do-wrap
   "Traverse the given form and wrap all its sub-forms in a function that evals
-   the form and records that it was called."
+  the form and records that it was called."
   (fn [f line form env]
     (form-type form env)))
 
@@ -166,7 +166,7 @@
 (defn wrap-binding
   "Wrap a let/loop binding
 
-   e.g. - `a (+ a b)`       (let or loop)"
+  e.g. - `a (+ a b)`       (let or loop)"
   [f line-hint [args & body :as form]]
   (tprnl "Wrapping overload" args body)
   (let [line (or (:line (meta form)) line-hint)]
@@ -176,7 +176,7 @@
 (defn wrap-overload
   "Wrap a single function overload.
 
-   e.g. - ([a b] (+ a b)) or
+  e.g. - ([a b] (+ a b)) or
           ([n] {:pre [(> n 0)]} (/ 1 n))"
   [f line-hint [args & body :as form]]
   (tprnl "Wrapping function overload" args body)
@@ -187,8 +187,8 @@
                 (zipmap (keys conds)
                         (map (fn [exprs] (vec (map (wrapper f line) exprs)))
                              (vals conds)))) ; must not wrap the vector itself
-         ;; i.e. [(> n 1)] -> [(do (> n 1))], not (do [...])
-         ;; the message of AssertionErrors will be different, too bad.
+        ;; i.e. [(> n 1)] -> [(do (> n 1))], not (do [...])
+        ;; the message of AssertionErrors will be different, too bad.
         body  (if conds (next body) body)
         wrapped (doall (map (wrapper f line) body))]
     `(~args

--- a/cloverage/src/cloverage/kahn.clj
+++ b/cloverage/src/cloverage/kahn.clj
@@ -29,8 +29,8 @@
 
 (defn kahn-sort
   "Proposes a topological sort for directed graph g using Kahn's
-   algorithm, where g is a map of nodes to sets of nodes. If g is
-   cyclic, returns nil."
+  algorithm, where g is a map of nodes to sets of nodes. If g is
+  cyclic, returns nil."
   ([g]
    (kahn-sort (normalize g) [] (no-incoming g)))
   ([g l s]

--- a/cloverage/src/cloverage/report.clj
+++ b/cloverage/src/cloverage/report.clj
@@ -79,4 +79,3 @@
         forms      (total :forms)]
     {:percent-lines-covered (if (= lines 0) 0. (* (/ (+ covered partial) lines) 100.0))
      :percent-forms-covered (if (= forms 0) 0. (* (/ cov-forms forms) 100.0))}))
-

--- a/cloverage/src/cloverage/report/codecov.clj
+++ b/cloverage/src/cloverage/report/codecov.clj
@@ -32,4 +32,3 @@
     (println "Writing codecov.io report to:" (.getAbsolutePath output-file))
     (with-out-writer output-file
       (json/pprint {:coverage covdata} :escape-slash false))))
-

--- a/cloverage/src/cloverage/report/coveralls.clj
+++ b/cloverage/src/cloverage/report/coveralls.clj
@@ -65,4 +65,3 @@
                     :service_name service
                     :source_files covdata}
                    :escape-slash false))))
-

--- a/cloverage/src/cloverage/report/emma_xml.clj
+++ b/cloverage/src/cloverage/report/emma_xml.clj
@@ -41,4 +41,3 @@
                          (map #(counters->cov :package (% :lib) %) by-pkg))]]
           xml/sexp-as-element
           (xml/emit wr)))))
-

--- a/cloverage/src/cloverage/report/html.clj
+++ b/cloverage/src/cloverage/report/html.clj
@@ -140,11 +140,10 @@ Both arguments are java.io.File"
                           :else            "not-tracked")]
             (printf
              "<span class=\"%s\" title=\"%d out of %d forms covered\">
-                 %03d&nbsp;&nbsp;%s
+                %03d&nbsp;&nbsp;%s
                 </span><br/>%n"
              cls (:hit line) (:total line)
              (:line line)
              (cs/escape (:text line " ") html-escapes))))
         (println " </body>")
         (println "</html>")))))
-

--- a/cloverage/src/cloverage/report/lcov.clj
+++ b/cloverage/src/cloverage/report/lcov.clj
@@ -23,4 +23,3 @@
   (let [output-file (io/file out-dir "lcov.info")]
     (println "Writing LCOV report to:" (.getAbsolutePath output-file))
     (with-out-writer output-file (write-lcov-report forms))))
-

--- a/cloverage/src/cloverage/report/raw.clj
+++ b/cloverage/src/cloverage/report/raw.clj
@@ -14,4 +14,3 @@
     (println "Writing raw stats to:" (.getAbsolutePath raw-stats-file))
     (with-out-writer raw-stats-file
       (clojure.pprint/pprint stats))))
-

--- a/cloverage/test/cloverage/args_test.clj
+++ b/cloverage/test/cloverage/args_test.clj
@@ -1,0 +1,30 @@
+(ns cloverage.args-test
+  (:require [clojure.test :refer :all]
+            [cloverage.args :as args]))
+
+(deftest overwriting
+  (let [output (#'args/overwrite
+                {:string "string"
+                 :coll   '(1 2 3)
+                 :bool   true}
+                {:bool   false
+                 :coll   '(4)
+                 :string "new"})]
+    (testing "basic merging"
+      (is (= '(1 2 3 4)
+             (:coll output)))
+      (is (= "new"
+             (:string output))))
+
+    (testing "removing the invalid keys"
+      (let [output (#'args/overwrite
+                    {}
+                    {:test-ns-regex [#"" ""]
+                     :src-ns-path   [1]})]
+        (is (nil? (find output :src-ns-path)))))))
+
+(deftest fixing-options
+  (let [opts (first (args/parse-args ["-p" "src1"] {:src-ns-path ["src2"]}))]
+    (testing "collections are concatenated"
+      (is (= '("src1" "src2")
+             (:src-ns-path opts))))))

--- a/cloverage/test/cloverage/coverage_test.clj
+++ b/cloverage/test/cloverage/coverage_test.clj
@@ -30,7 +30,7 @@
 
 (t/deftest preserves-type-hint
   (t/is (= 'long
-           ;; top level type hint always worked, but ones nested in :list did not
+          ;; top level type hint always worked, but ones nested in :list did not
            (-> (inst/wrap #'cov/track-coverage 0 '(prn ^long (long 0)))
                rw/macroexpand-all
                (nth 2) ; (do (cloverage/cover 0) (...)
@@ -211,7 +211,7 @@
                           "cloverage.sample.read-eval-sample"
                           "cloverage.sample.multibyte-sample"])))
   (t/testing "only matching namespaces (from classpath) are returned when only
-             regex patterns are provided:"
+            regex patterns are provided:"
     (t/testing "single pattern case"
       (t/is (= (cov/find-nses [] [#"^cloverage\.sample\.read.*$"])
                ["cloverage.sample.read-eval-sample"])))
@@ -222,7 +222,7 @@
                             "cloverage.coverage-test"
                             "cloverage.coverage"]))))
   (t/testing "only matching namespaces from a directory are returned when both path
-             and patterns are provided"
+            and patterns are provided"
     (t/is (= (cov/find-nses ["test/cloverage/sample"] [#".*dummy.*"])
              ["cloverage.sample.dummy-sample"]))))
 
@@ -246,4 +246,3 @@
        "--emma-xml"
        "-x" "cloverage.sample.cyclic-dependency"
        "cloverage.sample.cyclic-dependency")))))
-

--- a/cloverage/test/cloverage/dependency_test.clj
+++ b/cloverage/test/cloverage/dependency_test.clj
@@ -6,14 +6,14 @@
                   :incanter-core
                   {:ns-source
                    '(ns ^{:doc "This is the core numerics library for Incanter.
-               It provides functions for vector- and matrix-based
-               mathematical operations and the core data manipulation
-               functions for Incanter.
+              It provides functions for vector- and matrix-based
+              mathematical operations and the core data manipulation
+              functions for Incanter.
 
-               This library is built on Parallel Colt
-               (http://sites.google.com/site/piotrwendykier/software/parallelcolt)
-               an extension of the Colt numerics library
-               (http://acs.lbl.gov/~hoschek/colt/).
+              This library is built on Parallel Colt
+              (http://sites.google.com/site/piotrwendykier/software/parallelcolt)
+              an extension of the Colt numerics library
+              (http://acs.lbl.gov/~hoschek/colt/).
               "
                           :author "David Edgar Liebke"}
 
@@ -76,7 +76,7 @@
   (doall (for [[ns-name
                 {ns-form :ns-source expected :expected}] (seq ns-fixtures)]
            (let [result (cd/dependency-libs ns-form)]
-             ;; wrap in seq to work around lack of LazySeq.toString
+            ;; wrap in seq to work around lack of LazySeq.toString
              (t/is (= expected result)
                    (str "Parsing " ns-name
                         " should give " expected

--- a/lein-cloverage/project.clj
+++ b/lein-cloverage/project.clj
@@ -2,9 +2,9 @@
   :description "Lein plugin for cloverage"
   :url "https://github.com/cloverage/cloverage"
   :scm {:name "git"
-        :dir  ".."
-        :url  "https://www.github.com/cloverage/cloverage"
-        :tag  "HEAD"}
+      :dir  ".."
+      :url  "https://www.github.com/cloverage/cloverage"
+      :tag  "HEAD"}
   :vcs :git
   :license {:name "Eclipse Public License - v 1.0"
             :url "http://www.eclipse.org/legal/epl-v10.html"
@@ -12,10 +12,10 @@
             :comments "same as Clojure"}
   :plugins [[lein-release "1.0.9"]]
   :lein-release {:scm :git ; Because we're not in the top-level directory, so it doesn't auto-detect
-                 :deploy-via :clojars}
+                  :deploy-via :clojars}
   :deploy-repositories [["clojars" {:username :env/clojars_username :password :env/clojars_password :sign-releases false}]]
   :min-lein-version "2.0.0"
   :profiles {:dev {:plugins [[lein-cljfmt "0.5.7"]
-                             [jonase/eastwood "0.2.5"]
-                             [lein-kibit "0.1.6"]]}}
+                              [jonase/eastwood "0.2.5"]
+                              [lein-kibit "0.1.6"]]}}
   :eval-in-leiningen true)

--- a/lein-cloverage/src/leiningen/cloverage.clj
+++ b/lein-cloverage/src/leiningen/cloverage.clj
@@ -8,8 +8,8 @@
 
 (defn already-has-cloverage? [project]
   (seq (for [[id _version] (:dependencies project)
-            :when (= id 'cloverage/cloverage)]
-        true)))
+             :when (= id 'cloverage/cloverage)]
+         true)))
 
 (defn ^:pass-through-help cloverage
   "Run code coverage on the project.
@@ -23,10 +23,10 @@
   (let [project (if (already-has-cloverage? project)
                   project
                   (update-in project [:dependencies]
-                            conj    ['cloverage (get-lib-version)]))
+                             conj    ['cloverage (get-lib-version)]))
         opts    (assoc (:cloverage project)
-                  :src-ns-path (vec (:source-paths project))
-                  :test-ns-path (vec (:test-paths project)))]
+                       :src-ns-path (vec (:source-paths project))
+                       :test-ns-path (vec (:test-paths project)))]
     (try
       (eval/eval-in-project project
                             `(cloverage.coverage/run-project ~opts ~@args)

--- a/lein-cloverage/src/leiningen/cloverage.clj
+++ b/lein-cloverage/src/leiningen/cloverage.clj
@@ -8,8 +8,8 @@
 
 (defn already-has-cloverage? [project]
   (seq (for [[id _version] (:dependencies project)
-             :when (= id 'cloverage/cloverage)]
-         true)))
+            :when (= id 'cloverage/cloverage)]
+        true)))
 
 (defn ^:pass-through-help cloverage
   "Run code coverage on the project.
@@ -23,7 +23,7 @@
   (let [project (if (already-has-cloverage? project)
                   project
                   (update-in project [:dependencies]
-                             conj    ['cloverage (get-lib-version)]))
+                            conj    ['cloverage (get-lib-version)]))
         opts    (assoc (:cloverage project)
                   :src-ns-path (vec (:source-paths project))
                   :test-ns-path (vec (:test-paths project)))]


### PR DESCRIPTION
Change the leiningen/cloverage task to read the `:cloverage` key and pass into the library
Add extra entry point to read project options
Attempt to gracefully merge command-line and project options.
Move all arguments code into separate namespace.

Fixes [#155]