### PR TITLE
Add an explicit profile for Travis to do deploys

### DIFF
--- a/.travis.profiles.clj
+++ b/.travis.profiles.clj
@@ -1,0 +1,2 @@
+;; this file sets profiles for use under Travis CI, so that Travis can deploy master build snapshots
+{:deploy-repositories [["clojars" {:username :env/clojars_username :password :env/clojars_password :sign-releases false}]]}

--- a/cloverage/project.clj
+++ b/cloverage/project.clj
@@ -12,7 +12,6 @@
           :url "http://www.eclipse.org/legal/epl-v10.html"
           :distribution :repo
           :comments "same as Clojure"}
-  :deploy-repositories [["clojars" {:username :env/clojars_username :password :env/clojars_password :sign-releases false}]]
   :plugins [[lein-release "1.0.9"]]
   :lein-release {:scm :git ; Because we're not in the top-level directory, so it doesn't auto-detect
                     :deploy-via :clojars}

--- a/deploy.sh
+++ b/deploy.sh
@@ -5,6 +5,8 @@ elif [ x${TRAVIS_BRANCH} != xmaster ]; then
   echo "On branch '$TRAVIS_BRANCH' which isn't master so not doing a deploy"
 else
   echo "Not a pull request, so deploying"
+  cp .travis.profiles.clj cloverage
   (cd cloverage && lein deploy clojars)
+  cp .travis.profiles.clj lein-cloverage
   (cd lein-cloverage && lein deploy clojars)
 fi

--- a/lein-cloverage/project.clj
+++ b/lein-cloverage/project.clj
@@ -13,7 +13,6 @@
   :plugins [[lein-release "1.0.9"]]
   :lein-release {:scm :git ; Because we're not in the top-level directory, so it doesn't auto-detect
                   :deploy-via :clojars}
-  :deploy-repositories [["clojars" {:username :env/clojars_username :password :env/clojars_password :sign-releases false}]]
   :min-lein-version "2.0.0"
   :profiles {:dev {:plugins [[lein-cljfmt "0.5.7"]
                               [jonase/eastwood "0.2.5"]


### PR DESCRIPTION
See https://github.com/cloverage/cloverage/issues/213#issuecomment-400094618

Right now the default of using an env-supplied username and password with no signing makes deploys unnecessarily complicated. Most people will just have a credentials.clj.gpg, and lein deploy/lein release should just work already.

cc @rm-hull 