### PR TITLE
Fix Travis CI explicit profile

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -5,8 +5,8 @@ elif [ x${TRAVIS_BRANCH} != xmaster ]; then
   echo "On branch '$TRAVIS_BRANCH' which isn't master so not doing a deploy"
 else
   echo "Not a pull request, so deploying"
-  cp .travis.profiles.clj cloverage
+  cp .travis.profiles.clj cloverage/profiles.clj
   (cd cloverage && lein deploy clojars)
-  cp .travis.profiles.clj lein-cloverage
+  cp .travis.profiles.clj lein-cloverage/profiles.clj
   (cd lein-cloverage && lein deploy clojars)
 fi


### PR DESCRIPTION
In hindsight, the reason this didn't work is obvious: you can't just put a profiles.clj with any old name in that directory any expect it to work...
