### PR TITLE
Quote the arguments when passing them to cloverage.coverage/run-project

### DIFF
--- a/lein-cloverage/src/leiningen/cloverage.clj
+++ b/lein-cloverage/src/leiningen/cloverage.clj
@@ -29,7 +29,7 @@
                        :test-ns-path (vec (:test-paths project)))]
     (try
       (eval/eval-in-project project
-                            `(cloverage.coverage/run-project ~opts ~@args)
+                            `(cloverage.coverage/run-project '~opts ~@args)
                             '(require 'cloverage.coverage))
       (catch ExceptionInfo e
         (main/exit (:exit-code (ex-data e) 1))))))


### PR DESCRIPTION
Currently project.clj's `:cloverage` configuration is implicitly evaled as it's passed into cloverage. This mostly isn't a big deal until I try to merge configuration via profiles:
```clojure
(defproject myproject
  ...
  :cloverage {:ns-exclude-regex [#"a"]}
  :profiles {:b {:cloverage {:ns-exclude-regex [#"b"]}}})
```
The merging of those profiles will turn `:ns-exclude-regex` into `(#"a" #"b")`, which throws an error because it gets evaled as an s-expression.