### PR TITLE
Add support for test selectors

### DIFF
--- a/cloverage/src/cloverage/args.clj
+++ b/cloverage/src/cloverage/args.clj
@@ -87,7 +87,8 @@
                       (update :test-ns-regex ->regexes)
                       (update :ns-exclude-regex ->regexes)
                       (set/rename-keys boolean-flags)
-                      (overwrite project-settings))]
+                      (overwrite project-settings)
+                      (update :test-selectors #(into {} %)))]
     [opts add-nses help]))
 
 (def arguments
@@ -153,6 +154,10 @@
     "Additional test namespace (string) to add (can be repeated)."
     :default []
     :parse-fn (collecting-args-parser)]
+   ["--selector"
+    "Apply test selector (can be repeated)"
+    :default []
+    :parse-fn (comp (collecting-args-parser) parse-kw-str)]
    ["-c" "--custom-report"
     "Load and run a custom report writer. Should be a namespaced symbol. The function is passed
     project-options args-map output-directory forms"

--- a/lein-cloverage/src/leiningen/cloverage.clj
+++ b/lein-cloverage/src/leiningen/cloverage.clj
@@ -20,16 +20,18 @@
   Specify -o OUTPUTDIR for output directory, for other options run
   `lein cloverage --help`."
   [project & args]
-  (let [project (if (already-has-cloverage? project)
-                  project
-                  (update-in project [:dependencies]
-                             conj    ['cloverage (get-lib-version)]))
-        opts    (assoc (:cloverage project)
-                       :src-ns-path (vec (:source-paths project))
-                       :test-ns-path (vec (:test-paths project)))]
+  (let [project        (if (already-has-cloverage? project)
+                         project
+                         (update-in project [:dependencies]
+                                    conj ['cloverage (get-lib-version)]))
+        test-selectors (:test-selectors project)
+        opts           (assoc (:cloverage project)
+                              :src-ns-path (vec (:source-paths project))
+                              :test-ns-path (vec (:test-paths project)))]
     (try
       (eval/eval-in-project project
-                            `(cloverage.coverage/run-project '~opts ~@args)
+                            ;; test-selectors needs unquoted here to be read as functions
+                            `(cloverage.coverage/run-project (assoc '~opts :test-selectors ~test-selectors) ~@args)
                             '(require 'cloverage.coverage))
       (catch ExceptionInfo e
         (main/exit (:exit-code (ex-data e) 1))))))


### PR DESCRIPTION
Add support for lein test selectors (solves https://github.com/cloverage/cloverage/issues/54 )

This has to differ a bit from the method used in lein.test or eftest since those both solve the problem in the lein layer. Because of how cloverage
 is set up to work with tracing and testing, that method proved to be incompatible.

Example selector map that I've tested this with (ran all 3 individually (i.e. `--selector :integration`, `--selector :unit`, & `--selector :required`, as well as with no selectors, and `--selector :integration --selector :unit`):

```clojure
:test-selectors {:required (fn [m]
                               (or (:integration m)
                                 (:unit m)))
                   :integration :integration
                   :unit        :unit}
```

Not entirely sure what the best way to write a test for this would be, so am open to advice on that.