### PR TITLE
Optimise cover fn – redux

### DIFF
--- a/cloverage/src/cloverage/coverage.clj
+++ b/cloverage/src/cloverage/coverage.clj
@@ -54,13 +54,6 @@
          (finally
            (copy :leiningen/skipped-test :test)))))
 
-(defmacro with-coverage [libs & body]
-  `(binding [*covered* (atom [])]
-     (println "Capturing code coverage for" ~libs)
-     (doseq [lib# ~libs]
-       (instrument #'track-coverage lib#))
-     ~@body
-     (gather-stats @*covered*)))
 
 (defn cover
   "Mark the given file and line in as having been covered."

--- a/cloverage/src/cloverage/coverage.clj
+++ b/cloverage/src/cloverage/coverage.clj
@@ -20,7 +20,8 @@
             [cloverage.report.text :as text]
             [cloverage.source :as src])
   (:import (java.io FileNotFoundException)
-           (clojure.lang IObj)))
+           (java.util.concurrent.atomic AtomicInteger)
+           (clojure.lang IDeref IObj)))
 
 (def ^:dynamic *instrumented-ns*) ;; currently instrumented ns
 (def ^:dynamic *covered* (atom []))
@@ -54,16 +55,19 @@
          (finally
            (copy :leiningen/skipped-test :test)))))
 
+(defn covered []
+  (mapv (fn [{:keys [^AtomicInteger hits] :as form}]
+          (merge form {:hits (.get hits) :covered (pos? (.get hits))}))
+        @*covered*))
 
 (defn cover
   "Mark the given file and line in as having been covered."
   [idx]
-  (let [covered (swap! *covered* #(if-let [{:keys [hits] :as data} (nth % idx nil)]
-                                    (assoc % idx (assoc data :covered true :hits (inc (or hits 0))))
-                                    %))]
-    (when-not (nth covered idx nil)
-      (log/warn (str "Couldn't track coverage for form with index " idx
-                     " covered has " (count covered) ".")))))
+  ;; Note well that this function is written to have minimal overhead. Make sure
+  ;; there are no reflection warnings and especially beware introducing any
+  ;; unnecessary coordination here – it can greatly affect performance when
+  ;; instrumenting tests that use multithreading.
+  (.getAndIncrement ^AtomicInteger (get (nth (.deref ^IDeref *covered*) idx) :hits)))
 
 (defmacro capture
   "Eval the given form and record that the given line on the given
@@ -73,10 +77,9 @@
      (cover ~idx)
      ~form))
 
-(defn add-form
-  "Adds a structure representing the given form to the *covered* vector."
+(defn parse-form
   [form line-hint]
-  (debug/tprnl "Adding form" form "at line" (:line (meta form)) "hint" line-hint)
+  (debug/tprnl "Parsing form" form "at line" (:line (meta form)) "hint" line-hint)
   (let [lib       *instrumented-ns*
         file      (src/resource-path lib)
         line      (or (:line (meta form)) line-hint)
@@ -86,22 +89,17 @@
                    :tracked   true
                    :line      line
                    :lib       lib
-                   :file      file}]
+                   :file      file
+                   :hits      (AtomicInteger. 0)}]
     (binding [*print-meta* true]
-      (debug/tprn "Parsed form" form)
-      (debug/tprn "Adding" form-info))
-    (->
-     (swap! *covered* conj form-info)
-     count
-     dec)))
+      (debug/tprn "Parsed form" form))
+    form-info))
 
 (defn track-coverage [line-hint form]
   (debug/tprnl "Track coverage called with" form)
-  (let [idx   (count @*covered*)
-        form' (if (instance? IObj form)
-                (vary-meta form assoc :idx idx)
-                form)]
-    `(capture ~(add-form form' line-hint) ~form')))
+  (let [form' (parse-form form line-hint)
+        idx   (dec (count (swap! *covered* conj form')))]
+    `(capture ~idx ~form)))
 
 (defn mark-loaded [namespace]
   (binding [*ns* (find-ns 'clojure.core)]
@@ -248,7 +246,7 @@
                                   (form-for-suppressing-unselected-tests test-ns-symbols
                                                                          (vals (select-keys test-selectors selector))
                                                                          #((runner-fn opts) test-ns-symbols)))))
-                forms       (rep/gather-stats @*covered*)
+                forms       (rep/gather-stats (covered))
                 ;; sum up errors as in lein test
                 errors      (when test-result
                               (:errors test-result))

--- a/cloverage/test/cloverage/coverage_test.clj
+++ b/cloverage/test/cloverage/coverage_test.clj
@@ -148,7 +148,8 @@
 
 (t/deftest test-eval-ns
   (eval (inst/wrap #'cov/track-coverage 0 '(ns foo.bar)))
-  (t/is (= (count (filter :tracked @cov/*covered*)) (count (filter :covered @cov/*covered*)))))
+  (t/is (= (count (filter :tracked (cov/covered)))
+           (count (filter :covered (cov/covered))))))
 
 (t/deftest test-eval-case
   (doseq [x '[a b 3 #{3} fallthrough]]


### PR DESCRIPTION
Followup to #90.

Cloverage adds some significant overhead to the `cider-nrepl`  test suite. If you checkout clojure-emacs/cider-nrepl@8843848d8f1469d0cfe660cf67f41bbdcd81e9a5 and compare:

```
$ time lein test
... output elided ...
real	0m37.047s
user	2m7.759s
sys	0m3.905s
```

```
$ time lein with-profile +cloverage cloverage
... output elided ...
real	2m4.115s
user	5m18.812s
sys	0m6.361s
```

and with the changes in this PR:

```
$ time lein with-profile +cloverage cloverage
... output elided ...
real	0m45.508s
user	2m36.176s
sys	0m4.720s
```

So the overhead in this case is reduced from 87.1s to 8.5s.

The main change is to track hits by mutating a separate `java.util.concurrent.atomic.AtomicInteger` for each instrumented form, rather than mutating the global `*covered*` atom. If the instrumented code uses multithreading there can be a lot of contention on this atom! I have added a comment in the body of `cover` which explains that it is a performance-sensitive part of the code, and to be mindful of that when modifying it.

Also removed in this PR:

* `with-coverage`, a macro which is no longer used in the codebase
* The warning code path in `cover` that was never actually reached
* A call to `vary-meta`, since nothing is actually reading the `:idx` that it adds to the metadata

See below for before/after compared using the sampling profiler in YourKit.

<img width="1463" alt="screenshot 2019-01-27 22 46 36" src="https://user-images.githubusercontent.com/1759291/51807967-85112980-2285-11e9-8244-da125e8846c7.png">

<img width="1463" alt="screenshot 2019-01-27 22 46 43" src="https://user-images.githubusercontent.com/1759291/51807970-893d4700-2285-11e9-8dd4-3e531750ad87.png">

