### PR TITLE
Provide separate error when no namespaces selected for instrumentation

### DIFF
--- a/cloverage/src/cloverage/coverage.clj
+++ b/cloverage/src/cloverage/coverage.clj
@@ -222,6 +222,11 @@
           (println "Loading namespaces: " (apply list namespaces))
           (println "Test namespaces: " test-nses)
 
+          (when (empty? namespaces)
+            (throw (RuntimeException.
+                    (str "No namespaces selected for instrumentation using " {:ns-regex ns-regex
+                                                                              :ns-exclude-regex ns-exclude-regex}))))
+
           (if (empty? ordered-nses)
             (throw (RuntimeException. "Cannot instrument namespaces; there is a cyclic dependency"))
             (doseq [namespace ordered-nses]

--- a/cloverage/test/cloverage/coverage_test.clj
+++ b/cloverage/test/cloverage/coverage_test.clj
@@ -247,3 +247,15 @@
        "--emma-xml"
        "-x" "cloverage.sample.cyclic-dependency"
        "cloverage.sample.cyclic-dependency")))))
+
+(t/deftest test-no-ns-found-for-instrumentation
+  (binding [cloverage.coverage/*exit-after-test* false]
+    (t/testing "Expect validation error when no namespaces are selected for instrumentation"
+     (t/is
+      (thrown-with-msg?
+       RuntimeException #"No namespaces selected for instrumentation.*"
+       (cloverage.coverage/-main
+        "-o" "out"
+        "--emma-xml"
+        "--ns-regex" "cloverage.*"
+        "--ns-exclude-regex" ".*"))))))

--- a/cloverage/test/cloverage/coverage_test.clj
+++ b/cloverage/test/cloverage/coverage_test.clj
@@ -251,11 +251,11 @@
 (t/deftest test-no-ns-found-for-instrumentation
   (binding [cloverage.coverage/*exit-after-test* false]
     (t/testing "Expect validation error when no namespaces are selected for instrumentation"
-     (t/is
-      (thrown-with-msg?
-       RuntimeException #"No namespaces selected for instrumentation.*"
-       (cloverage.coverage/-main
-        "-o" "out"
-        "--emma-xml"
-        "--ns-regex" "cloverage.*"
-        "--ns-exclude-regex" ".*"))))))
+      (t/is
+       (thrown-with-msg?
+        RuntimeException #"No namespaces selected for instrumentation.*"
+        (cloverage.coverage/-main
+         "-o" "out"
+         "--emma-xml"
+         "--ns-regex" "cloverage.*"
+         "--ns-exclude-regex" ".*"))))))


### PR DESCRIPTION
In those occasions when user provides invalid `lein-cloverage` configuration which results and no namespaces found by Cloverage for instrumentation, Cloverage fails with error that is rather confusing:
```
Cannot instrument namespaces; there is a cyclic dependency
```

In my case the real error was invalid configuration value for `:ns-regex`, but it wasn't immediately clear due to the confusing error about cycling dependency.