### PR TITLE
Add note to README regarding usage from Clojure CLI tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ project being tested, then run:
 
 Where *args-to-coverage* will usually be something like "-n 'ns.regex.*' -t 'text.ns.regex.*'"
 
+### Clojure CLI Tool
+
+To use cloverage in a Clojure CLI Project,
+`clj -Sdeps '{:deps {cloverage {:mvn/version "RELEASE"}}}' -m cloverage.coverage *args-to-coverage*`
+
+Where *args-to-coverage* will usually be something like "-p src -s test"
+
 
 ## Troubleshooting
 


### PR DESCRIPTION
Was able to get cloverage running in a Clojure CLI tool project (tools.deps, deps.edn, etc.). Here's how.