### PR TITLE
:exclude-call project setting should be collection of symbols

### DIFF
--- a/cloverage/src/cloverage/args.clj
+++ b/cloverage/src/cloverage/args.clj
@@ -13,6 +13,10 @@
   (every? #(or (string? %)
                (instance? Pattern %)) coll))
 
+(defn- symbols?
+  [coll]
+  (every? symbol? coll))
+
 (def valid
   {:text?            boolean?
    :html?            boolean?
@@ -33,7 +37,7 @@
    :ns-regex         regexes-or-strings?
    :test-ns-regex    regexes-or-strings?
    :ns-exclude-regex regexes-or-strings?
-   :exclude-call     regexes-or-strings?
+   :exclude-call     symbols?
    :src-ns-path      regexes-or-strings?
    :runner           keyword?
    :test-ns-path     regexes-or-strings?


### PR DESCRIPTION
`:exclude-call` project setting currently doesn't work, as it only accepts strings or regexes, which are never converted to symbols to be checked against current form symbol in `instrument/do-wrap :list`.