### PR TITLE
Use Ubuntu Trusty on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: clojure
 lein: 2.8.1
 sudo: false
 
+dist: trusty
+
 install:
   # Get recent node:
   - . $HOME/.nvm/nvm.sh


### PR DESCRIPTION
The last few builds failed on Travis due to incompatibilities between
the default Ubuntu distribution (xenial) and the test matrix against
different JDKs. Following this thread:

https://travis-ci.community/t/error-installing-oraclejdk8-expected-feature-release-number-in-range-of-9-to-14-but-got-8/3766/4

seems like setting the `dist` to `trusty` should fix the issue