### PR TITLE
Update dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.0
 jobs:
   build:
     docker:
-      - image: clojure:lein-2.8.1
+      - image: clojure:lein-2.9.1
     steps:
       - checkout
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: clojure
-lein: 2.8.1
+lein: 2.9.1
 sudo: false
 
 dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,9 @@ cache:
     - $HOME/.m2
 
 jdk:
-  - oraclejdk9
-  - openjdk7
   - openjdk8
+  - openjdk9
+  - openjdk11
 
 after_success:
   - bash deploy.sh

--- a/cloverage/project.clj
+++ b/cloverage/project.clj
@@ -25,7 +25,7 @@
                  [slingshot "0.12.2"]]
   :profiles {:dev {:aot ^:replace []
                    :dependencies [[org.clojure/clojure "1.8.0"]]
-                   :plugins [[lein-cljfmt "0.5.7"]
+                   :plugins [[lein-cljfmt "0.6.4"]
                              [jonase/eastwood "0.2.5"]
                              [lein-kibit "0.1.6"]]
                    :eastwood {:exclude-linters [:no-ns-form-found]}

--- a/cloverage/project.clj
+++ b/cloverage/project.clj
@@ -24,7 +24,7 @@
                  [riddley "0.2.0"]
                  [slingshot "0.12.2"]]
   :profiles {:dev {:aot ^:replace []
-                   :dependencies [[org.clojure/clojure "1.8.0"]]
+                   :dependencies [[org.clojure/clojure "1.10.1"]]
                    :plugins [[lein-cljfmt "0.6.4"]
                              [jonase/eastwood "0.3.6"]
                              [lein-kibit "0.1.7"]]
@@ -36,5 +36,6 @@
              :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
-             :master {:dependencies [[org.clojure/clojure "1.9.0-master-SNAPSHOT"]]}}
-  :aliases {"all" ["with-profile" "+1.4:+1.5:+1.6:+1.7:+1.8:+master"]})
+             :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
+             :1.10 {:dependencies [[org.clojure/clojure "1.10.1"]]}}
+  :aliases {"all" ["with-profile" "+1.4:+1.5:+1.6:+1.7:+1.8:+1.9:+1.10"]})

--- a/cloverage/project.clj
+++ b/cloverage/project.clj
@@ -26,7 +26,7 @@
   :profiles {:dev {:aot ^:replace []
                    :dependencies [[org.clojure/clojure "1.8.0"]]
                    :plugins [[lein-cljfmt "0.6.4"]
-                             [jonase/eastwood "0.2.5"]
+                             [jonase/eastwood "0.3.6"]
                              [lein-kibit "0.1.6"]]
                    :eastwood {:exclude-linters [:no-ns-form-found]}
                    :global-vars {*warn-on-reflection* true}}

--- a/cloverage/project.clj
+++ b/cloverage/project.clj
@@ -27,7 +27,7 @@
                    :dependencies [[org.clojure/clojure "1.8.0"]]
                    :plugins [[lein-cljfmt "0.6.4"]
                              [jonase/eastwood "0.3.6"]
-                             [lein-kibit "0.1.6"]]
+                             [lein-kibit "0.1.7"]]
                    :eastwood {:exclude-linters [:no-ns-form-found]}
                    :global-vars {*warn-on-reflection* true}}
              :sample {:source-paths ["sample"]}

--- a/cloverage/project.clj
+++ b/cloverage/project.clj
@@ -17,7 +17,7 @@
                          :creds :gpg}}
   :dependencies [[org.clojure/tools.reader "1.1.2"]
                  [org.clojure/tools.cli "0.4.2"]
-                 [org.clojure/tools.logging "0.4.0"]
+                 [org.clojure/tools.logging "0.5.0"]
                  [org.clojure/data.xml "0.0.8"]
                  [org.clojure/data.json "0.2.6"]
                  [timofreiberg/bultitude "0.2.10"]

--- a/cloverage/project.clj
+++ b/cloverage/project.clj
@@ -21,7 +21,7 @@
                  [org.clojure/data.xml "0.0.8"]
                  [org.clojure/data.json "0.2.6"]
                  [timofreiberg/bultitude "0.3.0"]
-                 [riddley "0.1.14"]
+                 [riddley "0.2.0"]
                  [slingshot "0.12.2"]]
   :profiles {:dev {:aot ^:replace []
                    :dependencies [[org.clojure/clojure "1.8.0"]]

--- a/cloverage/project.clj
+++ b/cloverage/project.clj
@@ -16,7 +16,7 @@
                         {:url "https://repo.clojars.org"
                          :creds :gpg}}
   :dependencies [[org.clojure/tools.reader "1.1.2"]
-                 [org.clojure/tools.cli "0.3.5"]
+                 [org.clojure/tools.cli "0.4.2"]
                  [org.clojure/tools.logging "0.4.0"]
                  [org.clojure/data.xml "0.0.8"]
                  [org.clojure/data.json "0.2.6"]

--- a/cloverage/project.clj
+++ b/cloverage/project.clj
@@ -20,7 +20,7 @@
                  [org.clojure/tools.logging "0.5.0"]
                  [org.clojure/data.xml "0.0.8"]
                  [org.clojure/data.json "0.2.6"]
-                 [timofreiberg/bultitude "0.2.10"]
+                 [timofreiberg/bultitude "0.3.0"]
                  [riddley "0.1.14"]
                  [slingshot "0.12.2"]]
   :profiles {:dev {:aot ^:replace []

--- a/cloverage/project.clj
+++ b/cloverage/project.clj
@@ -2,39 +2,39 @@
   :description "Form-level test coverage for clojure."
   :url "https://www.github.com/cloverage/cloverage"
   :scm {:name "git"
-          :dir  ".."
-          :url  "https://www.github.com/cloverage/cloverage"
-          :tag  "HEAD"}
+        :dir ".."
+        :url "https://www.github.com/cloverage/cloverage"
+        :tag "HEAD"}
   :vcs :git
   :main ^:skip-aot cloverage.coverage
   :aot [clojure.tools.reader]
   :license {:name "Eclipse Public License - v 1.0"
-          :url "http://www.eclipse.org/legal/epl-v10.html"
-          :distribution :repo
-          :comments "same as Clojure"}
+            :url "http://www.eclipse.org/legal/epl-v10.html"
+            :distribution :repo
+            :comments "same as Clojure"}
   :deploy-repositories {"releases"
                         {:url "https://repo.clojars.org"
                          :creds :gpg}}
   :dependencies [[org.clojure/tools.reader "1.1.2"]
-                    [org.clojure/tools.cli "0.3.5"]
-                    [org.clojure/tools.logging "0.4.0"]
-                    [org.clojure/data.xml "0.0.8"]
-                    [org.clojure/data.json "0.2.6"]
-                    [timofreiberg/bultitude "0.2.10"]
-                    [riddley "0.1.14"]
-                    [slingshot "0.12.2"]]
+                 [org.clojure/tools.cli "0.3.5"]
+                 [org.clojure/tools.logging "0.4.0"]
+                 [org.clojure/data.xml "0.0.8"]
+                 [org.clojure/data.json "0.2.6"]
+                 [timofreiberg/bultitude "0.2.10"]
+                 [riddley "0.1.14"]
+                 [slingshot "0.12.2"]]
   :profiles {:dev {:aot ^:replace []
                    :dependencies [[org.clojure/clojure "1.8.0"]]
                    :plugins [[lein-cljfmt "0.5.7"]
                              [jonase/eastwood "0.2.5"]
                              [lein-kibit "0.1.6"]]
-                    :eastwood {:exclude-linters [:no-ns-form-found]}
-                    :global-vars {*warn-on-reflection* true}}
-          :sample {:source-paths ["sample"]}
-          :1.4    {:dependencies [[org.clojure/clojure "1.4.0"]]}
-          :1.5    {:dependencies [[org.clojure/clojure "1.5.1"]]}
-          :1.6    {:dependencies [[org.clojure/clojure "1.6.0"]]}
-          :1.7    {:dependencies [[org.clojure/clojure "1.7.0"]]}
-          :1.8    {:dependencies [[org.clojure/clojure "1.8.0"]]}
-          :master {:dependencies [[org.clojure/clojure "1.9.0-master-SNAPSHOT"]]}}
+                   :eastwood {:exclude-linters [:no-ns-form-found]}
+                   :global-vars {*warn-on-reflection* true}}
+             :sample {:source-paths ["sample"]}
+             :1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}
+             :1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
+             :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
+             :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
+             :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
+             :master {:dependencies [[org.clojure/clojure "1.9.0-master-SNAPSHOT"]]}}
   :aliases {"all" ["with-profile" "+1.4:+1.5:+1.6:+1.7:+1.8:+master"]})

--- a/cloverage/project.clj
+++ b/cloverage/project.clj
@@ -15,7 +15,7 @@
   :deploy-repositories {"releases"
                         {:url "https://repo.clojars.org"
                          :creds :gpg}}
-  :dependencies [[org.clojure/tools.reader "1.1.2"]
+  :dependencies [[org.clojure/tools.reader "1.3.2"]
                  [org.clojure/tools.cli "0.4.2"]
                  [org.clojure/tools.logging "0.5.0"]
                  [org.clojure/data.xml "0.0.8"]

--- a/cloverage/test/cloverage/instrument_test.clj
+++ b/cloverage/test/cloverage/instrument_test.clj
@@ -45,8 +45,7 @@
   (t/is (= :list (form-type- '(+ 1 2))))
   (t/is (= :do (form-type- '(do 1 2 3))))
   (t/is (= :list (form-type- '(loop 1 2 3)
-                             {'loop 'hoop} ;fake a local binding
-))))
+                             {'loop 'hoop})))) ;fake a local binding
 
 (t/deftest do-wrap-for-record-returns-record
   (t/is (= 1 (method (eval (inst/wrap #'inst/nop 0 (Record. 1)))))))

--- a/lein-cloverage/project.clj
+++ b/lein-cloverage/project.clj
@@ -2,9 +2,9 @@
   :description "Lein plugin for cloverage"
   :url "https://github.com/cloverage/cloverage"
   :scm {:name "git"
-      :dir  ".."
-      :url  "https://www.github.com/cloverage/cloverage"
-      :tag  "HEAD"}
+        :dir ".."
+        :url "https://www.github.com/cloverage/cloverage"
+        :tag "HEAD"}
   :vcs :git
   :license {:name "Eclipse Public License - v 1.0"
             :url "http://www.eclipse.org/legal/epl-v10.html"

--- a/lein-cloverage/project.clj
+++ b/lein-cloverage/project.clj
@@ -31,5 +31,5 @@
   :min-lein-version "2.0.0"
   :profiles {:dev {:plugins [[lein-cljfmt "0.6.4"]
                              [jonase/eastwood "0.3.6"]
-                             [lein-kibit "0.1.6"]]}}
+                             [lein-kibit "0.1.7"]]}}
   :eval-in-leiningen true)

--- a/lein-cloverage/project.clj
+++ b/lein-cloverage/project.clj
@@ -30,6 +30,6 @@
 
   :min-lein-version "2.0.0"
   :profiles {:dev {:plugins [[lein-cljfmt "0.6.4"]
-                             [jonase/eastwood "0.2.5"]
+                             [jonase/eastwood "0.3.6"]
                              [lein-kibit "0.1.6"]]}}
   :eval-in-leiningen true)

--- a/lein-cloverage/project.clj
+++ b/lein-cloverage/project.clj
@@ -29,7 +29,7 @@
                   ["vcs" "push"]]
 
   :min-lein-version "2.0.0"
-  :profiles {:dev {:plugins [[lein-cljfmt "0.5.7"]
+  :profiles {:dev {:plugins [[lein-cljfmt "0.6.4"]
                              [jonase/eastwood "0.2.5"]
                              [lein-kibit "0.1.6"]]}}
   :eval-in-leiningen true)


### PR DESCRIPTION
Update all of Cloverage's dependencies, most importantly the AOT-ed `tools.reader` dependency.