### PR TITLE
Add -Duser.language=en-US to JVM opts during tests

### DIFF
--- a/cloverage/project.clj
+++ b/cloverage/project.clj
@@ -38,5 +38,6 @@
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
-             :1.10 {:dependencies [[org.clojure/clojure "1.10.1"]]}}
+             :1.10 {:dependencies [[org.clojure/clojure "1.10.1"]]}
+             :test {:jvm-opts ["-Duser.language=en-US"]}}
   :aliases {"all" ["with-profile" "+1.4:+1.5:+1.6:+1.7:+1.8:+1.9:+1.10"]})


### PR DESCRIPTION
Tests on number formatting assume the `en_US` format with a dot to separate decimals. In other environment this format might be different, e.g. `fr_FR` uses a comma:

* `en_US`: `3.14`
* `fr_FR`: `3,14`

This change ensures we’re always in an `en_US` environment when running the tests.

Fixes #262.