### PR TITLE
Fix instrumenting let forms

### DIFF
--- a/cloverage/src/cloverage/instrument.clj
+++ b/cloverage/src/cloverage/instrument.clj
@@ -281,7 +281,7 @@
            (list let-sym (wrap-bindings f line bindings env))
            (vec
             (for [form body]
-              (do-wrap f (or (:line (meta form))) form env))))))
+              (do-wrap f (or (:line (meta form)) line) form env))))))
 
 (defmethod do-wrap :letfn [f line [_ bindings & _ :as form] _]
   ;; (letfn [(foo [bar] ...) ...] body) ->

--- a/cloverage/test/cloverage/instrument_test.clj
+++ b/cloverage/test/cloverage/instrument_test.clj
@@ -84,9 +84,6 @@
 (defmacro ^:private on-line [line-number form]
   `(with-meta ~form {:line ~line-number}))
 
-(defn wrapped [line-number form]
-  (list 'cloverage.instrument/wrapm 'cloverage.instrument/no-instr line-number form))
-
 (t/deftest test-wrap-let-form
   (t/testing "let should recurisvely wrap its forms"
     (let [form (list 'let ['x (list 'let ['y (on-line 3 '(+ 1 2))]


### PR DESCRIPTION
Unless I'm totally misunderstanding how things work, the old cold didn't instrument the values in `let` bindings -- so in a form like 

```clj
(let [x (let [y 2] (+ y 3))]
  (+ x 1))
```

`(+ x 1`) would get instrumented while `(+ y 3)` would not.

I added a test for this situation and fixed the instrumentation code for let. I also made some tweaks to make sure the forms are instrumented with the correct line number metadata