### PR TITLE
Fail gracefully if form cannot be instrumented

### DIFF
--- a/cloverage/src/cloverage/instrument.clj
+++ b/cloverage/src/cloverage/instrument.clj
@@ -466,7 +466,7 @@
 ;;
 ;; used to perform the instrumentation
 
-(defn- eval-instrumented-form
+(defn eval-form
   "Evaluate an `instrumented-form`."
   [filename form line-hint instrumented-form]
   (try
@@ -508,15 +508,17 @@
                                 (catch Throwable e
                                   (throw+ e "Couldn't wrap form %s at line %s"
                                           form line-hint)))]
-        (eval-instrumented-form filename form line-hint instrumented-form)
+        (eval-form filename form line-hint instrumented-form)
         instrumented-form)
-      ;; if we run into an error instrumenting a form, log it and return the uninstrumented form, so we can continue
+      ;; if we run into an error instrumenting a form, log it and return/eval the uninstrumented form, so we can
+      ;; continue
       (catch Throwable e
         (log/error "Error instrumenting form"
                    (ex-info "Error instrumenting form" {:filename filename
                                                         :line     line-hint
                                                         :form     form}
                             e))
+        (eval-form filename form line-hint form)
         form))))
 
 (defn instrument-file

--- a/cloverage/src/cloverage/instrument.clj
+++ b/cloverage/src/cloverage/instrument.clj
@@ -510,12 +510,14 @@
                                           form line-hint)))]
         (eval-instrumented-form filename form line-hint instrumented-form)
         instrumented-form)
+      ;; if we run into an error instrumenting a form, log it and return the uninstrumented form, so we can continue
       (catch Throwable e
-        (throw (ex-info "Error instrumenting form"
-                        {:filename filename
-                         :line     line-hint
-                         :form     form}
-                        e))))))
+        (log/error "Error instrumenting form"
+                   (ex-info "Error instrumenting form" {:filename filename
+                                                        :line     line-hint
+                                                        :form     form}
+                            e))
+        form))))
 
 (defn instrument-file
   "Instrument all the forms in a file. Returns sequence of instrumented forms."


### PR DESCRIPTION
Suggested in #257 -- if instrumenting a form fails for one reason or another it's better to skip instrumenting that form, log an error, and continue, rather than failing entirely. 

Ideally instrumentation would never fail for any forms but in rare edge-cases like #277 it's better to still be able to instrument the rest of the code.