### PR TITLE
Include "sample" source-paths in :test profile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_script:
   - (cd lein-cloverage && lein do cljfmt check, eastwood, kibit)
 
 script:
-  - (cd cloverage && lein with-profile +sample test)
+  - (cd cloverage && lein test)
   - (cd lein-cloverage && lein test)
 
 cache:

--- a/cloverage/project.clj
+++ b/cloverage/project.clj
@@ -34,7 +34,6 @@
                              [lein-kibit "0.1.7"]]
                    :eastwood {:exclude-linters [:no-ns-form-found]}
                    :global-vars {*warn-on-reflection* true}}
-             :sample {:source-paths ["sample"]}
              :1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}
              :1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
              :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
@@ -42,5 +41,6 @@
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
              :1.10 {:dependencies [[org.clojure/clojure "1.10.1"]]}
-             :test {:jvm-opts ["-Duser.language=en-US"]}}
+             :test {:source-paths ["sample"]
+                    :jvm-opts ["-Duser.language=en-US"]}}
   :aliases {"all" ["with-profile" "+1.4:+1.5:+1.6:+1.7:+1.8:+1.9:+1.10"]})


### PR DESCRIPTION
- Removes the `:sample` profile in favor of just moving what it was effectively doing into the `:test` profile.
- updates the `.travis.yml` file's `lein test` invocation
- fixes #221