### PR TITLE
Revert "Preserve metadata when wrapping collections"

### DIFF
--- a/cloverage/src/cloverage/instrument.clj
+++ b/cloverage/src/cloverage/instrument.clj
@@ -33,9 +33,10 @@
 
 (defn add-original [old new]
   (if (iobj? new)
-    (-> (propagate-line-numbers (:line (meta old)) new)
-        (vary-meta merge (meta old))
-        (vary-meta assoc :original old))
+    (let [res      (-> (propagate-line-numbers (:line (meta old)) new)
+                       (vary-meta merge (meta old))
+                       (vary-meta assoc :original old))]
+      res)
     new))
 
 (defn atomic-special? [sym]
@@ -261,7 +262,7 @@
                                 (throw+ (str "Can't construct empty " (class form))))
                               `(into ~(empty form) [] ~(vec wrappee))))]
     (d/tprn ":wrapped" (class form) (class wrapped) wrapped)
-    (f line (add-original form wrapped))))
+    (f line wrapped)))
 
 (defn wrap-fn-body [f line form]
   (let [fn-sym (first form)

--- a/cloverage/test/cloverage/instrument_test.clj
+++ b/cloverage/test/cloverage/instrument_test.clj
@@ -173,13 +173,6 @@
       (t/is (= 'java.lang.Runnable
                (:tag (meta (nth instrumented 3))))))))
 
-(t/deftest test-coll-preserves-metadata
-  (let [form         ^:preserved? [:foo :bar]
-        instrumented (macroexpand-1 (inst/instrument-form #'inst/no-instr
-                                                          nil
-                                                          form))]
-    (t/is (:preserved? (meta instrumented)))))
-
 (t/deftest fail-gracefully-when-instrumenting
   (t/testing "If instrumenting a form fails we should log an Exception and continue instead of failing entirely."
     (let [form                   '(this-function-does-not-exist 100)


### PR DESCRIPTION
This reverts commit a62098933039479dcb341cf95f3405eb702a256b.

#292 introduced a regression that can break existing test suites. It potentially causes collections to be evaluated twice, which may cause side-effects to be triggered twice.

We observed breakage with a scenario like this:
~~~clojure
(let [my-coll {:foo (some-fn ...)
               :bar 123}]
  ...)
~~~
Our test suite had redef'ed `some-fn` to be a dummy function that incremented a counter in an atom. With the changes in that commit, the function was run twice, leading to the counter being double incremented.

Unfortunately, I'm not quite familiar enough with cloverage to know how to fix this while keeping the intended behavior of preserving metadata, so I've simply proposed a revert for now.

Thanks for your work maintaining this very helpful tool!