### PR TITLE
Fix multiple evaluations of coll during instrumentation

### DIFF
--- a/cloverage/src/cloverage/instrument.clj
+++ b/cloverage/src/cloverage/instrument.clj
@@ -261,7 +261,7 @@
                                 (throw+ (str "Can't construct empty " (class form))))
                               `(into ~(empty form) [] ~(vec wrappee))))]
     (d/tprn ":wrapped" (class form) (class wrapped) wrapped)
-    (f line (add-original form wrapped))))
+    (f line (vary-meta wrapped merge (meta form)))))
 
 (defn wrap-fn-body [f line form]
   (let [fn-sym (first form)

--- a/cloverage/test/cloverage/instrument_test.clj
+++ b/cloverage/test/cloverage/instrument_test.clj
@@ -180,10 +180,12 @@
                                                           form))]
     (t/is (:preserved? (meta instrumented)))))
 
+(def test-coll-is-evaluated-once-count
+  "This needs to be reachable from global scope."
+  (atom 0))
+
 (t/deftest test-coll-is-evaluated-once
-  (def test-coll-is-evaluated-once-count
-    "This needs to be reachable from global scope."
-    (atom 0))
+  (reset! test-coll-is-evaluated-once-count 0)
   (inst/instrument-form #'inst/no-instr nil `{:foo (swap! test-coll-is-evaluated-once-count inc)})
   (t/is (= 1 @test-coll-is-evaluated-once-count)))
 

--- a/cloverage/test/cloverage/instrument_test.clj
+++ b/cloverage/test/cloverage/instrument_test.clj
@@ -180,6 +180,13 @@
                                                           form))]
     (t/is (:preserved? (meta instrumented)))))
 
+(t/deftest test-coll-is-evaluated-once
+  (def test-coll-is-evaluated-once-count
+    "This needs to be reachable from global scope."
+    (atom 0))
+  (inst/instrument-form #'inst/no-instr nil `{:foo (swap! test-coll-is-evaluated-once-count inc)})
+  (t/is (= 1 @test-coll-is-evaluated-once-count)))
+
 (t/deftest fail-gracefully-when-instrumenting
   (t/testing "If instrumenting a form fails we should log an Exception and continue instead of failing entirely."
     (let [form                   '(this-function-does-not-exist 100)


### PR DESCRIPTION
This is an alternative to #298 that continues to preserve collection metadata during instrumentation.