### PR TITLE
Propagate function call tag metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ in github. Commentary on the change should appear as a nested, unordered list.
   - Fix instrumention of inlined function calls like `int` (#277, #304)
   - Performance improvements (#304)
   - Instrument the class-or-instance part of Java interop forms (#306, #307)
+  - Propagate tag metadata when instrumenting function call forms (#308, #310)
 
 ## 1.2.0 (BUGFIX RELEASE)
 

--- a/cloverage/src/cloverage/coverage.clj
+++ b/cloverage/src/cloverage/coverage.clj
@@ -73,9 +73,11 @@
   "Eval the given form and record that the given line on the given
   files was run."
   [idx form]
-  `(do
-     (cover ~idx)
-     ~form))
+  (with-meta
+    `(do
+       (cover ~idx)
+       ~form)
+    (meta form)))
 
 (defn parse-form
   [form line-hint]

--- a/cloverage/src/cloverage/debug.clj
+++ b/cloverage/src/cloverage/debug.clj
@@ -1,19 +1,27 @@
 (ns cloverage.debug
-  (:require [clojure.pprint]
-            [clojure.java.io :refer [writer]]))
+  (:require [clojure.java.io :refer [writer]]
+            clojure.pprint))
 
-(def ^:dynamic *debug* false)
-;; debug output
-(defn tprn [& args]
+(def ^:dynamic *debug*
+  "Whether to enable Cloverage debugging output."
+  false)
+
+(defn tprn
+  "Like `clojure.pprint/pprint`, but only prints when Cloverage debugging is enabled."
+  [& args]
   (when *debug*
     (run! clojure.pprint/pprint args)
     (newline)))
 
-(defn tprnl [& args]
+(defn tprnl
+  "Like `println`, but only prints when Cloverage debugging is enabled."
+  [& args]
   (when *debug*
     (apply println args)))
 
-(defn tprf [& args]
+(defn tprf
+  "Like `printf`, but only prints when Cloverage debugging is enabled."
+  [& args]
   (when *debug*
     (apply printf args)))
 

--- a/cloverage/test/cloverage/instrument_test.clj
+++ b/cloverage/test/cloverage/instrument_test.clj
@@ -225,8 +225,8 @@
           instrumented (rw/macroexpand-all (inst/wrap #'inst/nop nil form))]
       (t/is (= '(do (let* [my-str (do (fn* ([& args]
                                             (do ((do apply) (do str) (do args))))))]
-                      (do (new java.lang.IllegalArgumentException
-                               (do ((do my-str) (do "No matching clause")))))))
+                          (do (new java.lang.IllegalArgumentException
+                                   (do ((do my-str) (do "No matching clause")))))))
                instrumented))
       (let [fn-call-form (-> instrumented last last last last)]
         (t/is (= '(do ((do my-str) (do "No matching clause")))

--- a/cloverage/test/cloverage/instrument_test.clj
+++ b/cloverage/test/cloverage/instrument_test.clj
@@ -190,12 +190,49 @@
 
 (t/deftest test-instrumenting-fn-forms-preserves-metadata
   (let [form         '(.submit clojure.lang.Agent/pooledExecutor ^java.lang.Runnable (fn []))
-        instrumented (rw/macroexpand-all (inst/instrument-form #'inst/no-instr nil ^{:line 1} form))]
-    (t/is (= '(. clojure.lang.Agent/pooledExecutor submit (fn* ([])))
+        instrumented (rw/macroexpand-all (inst/instrument-form #'inst/nop nil ^{:line 1} form))]
+    (t/is (= '(do (. clojure.lang.Agent/pooledExecutor submit (do (fn* ([])))))
              instrumented))
-    (t/testing "metadata on the fn form should be preserved"
-      (t/is (= 'java.lang.Runnable
-               (:tag (meta (nth instrumented 3))))))))
+    (let [[_ fn-form :as do-form] (-> instrumented last last)]
+      (t/testing "metadata on the fn form should be propagated to the wrapper instrumentation form"
+        (t/is (= '(do (fn* ([])))
+                 do-form))
+        (t/is (= 'java.lang.Runnable
+                 (:tag (meta do-form)))))
+      (t/testing "metadata on the fn form should be preserved"
+        (t/is (= '(fn* ([]))
+                 fn-form))
+        (t/is (= 'java.lang.Runnable
+                 (:tag (meta fn-form))))))))
+
+(t/deftest test-instrumenting-fn-call-forms-propogates-metadata
+  (t/testing "Tag info for a function call form should be included in the instrumented form (#308)"
+    ;; e.g. (str "Oops") -> ^String (do ((do str) (do "Oops")))
+    (let [form         '(new java.lang.IllegalArgumentException (str "No matching clause"))
+          instrumented (rw/macroexpand-all (inst/wrap #'inst/nop nil form))]
+      (t/is (= '(do (new java.lang.IllegalArgumentException (do ((do str) (do "No matching clause")))))
+               instrumented))
+      (let [fn-call-form (-> instrumented last last)]
+        (t/is (= '(do ((do str) (do "No matching clause")))
+                 fn-call-form))
+        (t/is (= java.lang.String
+                 (:tag (meta fn-call-form)))))))
+
+  (t/testing "Should also work if tag was specified on the entire form"
+    (let [form         '(let [my-str (fn [& args]
+                                       (apply str args))]
+                          (new java.lang.IllegalArgumentException ^String (my-str "No matching clause")))
+          instrumented (rw/macroexpand-all (inst/wrap #'inst/nop nil form))]
+      (t/is (= '(do (let* [my-str (do (fn* ([& args]
+                                            (do ((do apply) (do str) (do args))))))]
+                      (do (new java.lang.IllegalArgumentException
+                               (do ((do my-str) (do "No matching clause")))))))
+               instrumented))
+      (let [fn-call-form (-> instrumented last last last last)]
+        (t/is (= '(do ((do my-str) (do "No matching clause")))
+                 fn-call-form))
+        (t/is (= 'String
+                 (:tag (meta fn-call-form))))))))
 
 (t/deftest test-coll-preserves-metadata
   (let [form         ^:preserved? [:foo :bar]


### PR DESCRIPTION
A function call form like `(str "My String")` becomes `(do ... ((do ... str) (do ... "My String")))` and the compiler can no longer infer the type of the instrumented form, which can cause reflection warnings or even errors in some cases. This PR tweaks instrumentation logic to infer the type information from the function (`str`) and add it to the instrumented form itself (e.g. `^String (do ... ((do ... str) (do ... "My String")))`)

Fixes #308