### PR TITLE
Use Known Data Readers while Reading Forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ in github. Commentary on the change should appear as a nested, unordered list.
 
 ## 1.2.2 (WIP)
 
-Nothing yet!
+- Use Known Data Readers while Reading Forms
 
 ## 1.2.1
 

--- a/cloverage/src/cloverage/source.clj
+++ b/cloverage/src/cloverage/source.clj
@@ -75,7 +75,8 @@
   [source-reader]
   ;; `read-form` will return `nil` at the end of the file so keep reading forms until we run out
   (letfn [(read-form []
-            (binding [*read-eval* false]
+            (binding [*read-eval* false
+                      r/*data-readers* *data-readers*]
               (r/read {:eof       ::eof
                        :features  #{:clj}
                        :read-cond :allow}


### PR DESCRIPTION
While using Cloverage with Clojure CLI, my tagged literals defined in dependencies of my project are not available. However the dynamic var `clojure.core/*data-readers*` contains the definitions of all tagged literals from all libs because I run Cloverage with the appropriate classpath.

Because Cloverage is using `clojure.tools.reader` instead of the build-in Clojure reader, the tagged literal definitions have to be bound to `clojure.tools.reader/*data-readers*`.

This is related to: #255