### PR TITLE
Add ability to run Cloverage with Eftest runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ in github. Commentary on the change should appear as a nested, unordered list.
 ## 1.2.2 (WIP)
 
 - Use Known Data Readers while Reading Forms
+- Support for eftest as a test runner with `--runner :eftest` (#314)
 
 ## 1.2.1
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Add the following to your user-wide Leiningen profiles file `~/.lein/profiles.cl
 
 ## Testing frameworks support
 
-Cloverage uses `clojure.test` by default. If you prefer use `midje`, pass the `--runner :midje` flag. (In older versions of Cloverage, you had to wrap your midje tests in clojure.test's deftest. This is no longer necessary.) Other test libraries may ship with their own support for Cloverage external to this library; see their documentation for details.
+Cloverage uses `clojure.test` by default. If you prefer use `midje`, pass the `--runner :midje` flag. (In older versions of Cloverage, you had to wrap your midje tests in clojure.test's deftest. This is no longer necessary.) For using `eftest`, pass the `--runner :eftest` flag. Optionally you could configure a runner passing `:runner-opts` with a map in project settings. Other test libraries may ship with their own support for Cloverage external to this library; see their documentation for details.
 
 ## Usage
 
@@ -68,7 +68,8 @@ Available options and command-line arguments:
  :low-watermark    --low-watermark              50               Sets the low watermark percentage (valid values 0..100). Default: 50%
  :high-watermark   --high-watermark             80               Sets the high watermark percentage (valid values 0..100). Default: 80%
  :debug?           -d, --no-debug, --debug      false            Output debugging information to stdout.
- :runner           -r, --runner                 :clojure.test    Specify which test runner to use. Built-in runners are `clojure.test` and `midje`.
+ :runner           -r, --runner                 :clojure.test    Specify which test runner to use. Built-in runners are `clojure.test`, `midje` and `eftest`.
+ :runner-opts      (not allowed as a cli arg)   {}               Configure specified runner with any options map.
  :nop?             --no-nop, --nop              false            Instrument with noops.
  :ns-regex         -n, --ns-regex               []               Regex for instrumented namespaces (can be repeated).
  :ns-exclude-regex -e, --ns-exclude-regex       []               Regex for namespaces not to be instrumented (can be repeated).

--- a/cloverage/src/cloverage/args.clj
+++ b/cloverage/src/cloverage/args.clj
@@ -41,6 +41,7 @@
    :exclude-call     symbols?
    :src-ns-path      regexes-or-strings?
    :runner           keyword?
+   :runner-opts      map?
    :test-ns-path     regexes-or-strings?
    :custom-report    symbol?})
 
@@ -136,7 +137,7 @@
    ["-d" "--[no-]debug"
     "Output debugging information to stdout." :default false]
    ["-r" "--runner"
-    "Specify which test runner to use. Built-in runners are `clojure.test` and `midje`."
+    "Specify which test runner to use. Built-in runners are `clojure.test`, `midje` and `eftest`."
     :default :clojure.test
     :parse-fn parse-kw-str]
    ["--[no-]nop" "Instrument with noops." :default false]

--- a/cloverage/test/cloverage/coverage_test.clj
+++ b/cloverage/test/cloverage/coverage_test.clj
@@ -388,3 +388,31 @@
          "--emma-xml"
          "--ns-regex" "cloverage.*"
          "--ns-exclude-regex" ".*"))))))
+
+(t/deftest test-require-ns
+  (t/is (= 'cloverage.coverage-test
+           (ns-name (#'cov/require-ns "cloverage.coverage-test")))))
+
+(t/deftest test-runner-fn-eftest
+  (let [opts {:runner :eftest
+              :src-ns-path ["src"]
+              :test-ns-path ["test"]}]
+    (t/testing "check that eftest runner-fn just runs with opts as a seq of vectors, no errors"
+      (let [runner-opts {:runner-opts '([:test-warn-time 100]
+                                        [:multithread? false])}]
+        (with-redefs [cov/resolve-var (fn [x] (constantly {:error 0 :fail 0}))
+                      cov/find-nses (constantly [])
+                      cov/require-ns (constantly "test")
+                      require (constantly nil)]
+          (t/is (= {:errors 0}
+                   ((cov/runner-fn (merge opts runner-opts)) []))))))
+
+    (t/testing "check that eftest runner-fn just runs with opts as a map and returns errors"
+      (let [runner-opts {:runner-opts {:test-warn-time 100
+                                       :multithread? false}}]
+        (with-redefs [cov/resolve-var (fn [x] (constantly {:error 1 :fail 2}))
+                      cov/find-nses (constantly [])
+                      cov/require-ns (constantly "test")
+                      require (constantly nil)]
+          (t/is (= {:errors 3}
+                   ((cov/runner-fn (merge opts runner-opts)) []))))))))


### PR DESCRIPTION
An example of config for running with Leiningen:
```
{:plugins [[lein-cloverage "1.2.2-SNAPSHOT"]]
 :dependencies [[eftest/eftest "0.5.9"]]
 :cloverage {:runner :eftest
             :runner-opts {:test-warn-time 500
                           :fail-fast? true
                           :multithread? :namespaces}}}
```

And the same one to run with tools.deps:
```
{:extra-paths ["test"]
 :extra-deps {cloverage/cloverage {:mvn/version "1.2.2-SNAPSHOT"}
              eftest/eftest {:mvn/version "0.5.9"}}
 :exec-fn cloverage.coverage/run-project
 :exec-args {:test-ns-path ["test"]
             :src-ns-path ["src"]
             :runner :eftest
             :runner-opts {:test-warn-time 500
                           :fail-fast? true
                           :multithread? :namespaces}}}
```


Resolves: #314 