### PR TITLE
Fix loss of "isolated" namespaces during reordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ in github. Commentary on the change should appear as a nested, unordered list.
 
 ## 1.3.0
 
-Nothing yet!
+- Fix loss of isolated namespaces during reordering (#312)
 
 ## 1.2.2
 

--- a/cloverage/src/cloverage/dependency.clj
+++ b/cloverage/src/cloverage/dependency.clj
@@ -27,4 +27,7 @@
 (defn in-dependency-order
   "Sort a list of namespace symbols so that any namespace occurs after its dependencies."
   [ns-symbols]
-  (ns.deps/topo-sort (dependencies-graph ns-symbols)))
+  (-> (dependencies-graph ns-symbols)
+      ns.deps/topo-sort
+      (concat ns-symbols)
+      distinct))

--- a/cloverage/test/cloverage/dependency_test.clj
+++ b/cloverage/test/cloverage/dependency_test.clj
@@ -102,3 +102,12 @@
              clojure.lang.ExceptionInfo
              #"Circular dependency between c and a"
              (cd/in-dependency-order '[a b c]))))))
+
+(t/deftest isolated-namespace-test
+  (t/testing "Isolated namespaces should be included in the result"
+    (with-redefs [source/ns-form (fn [ns-symbol]
+                                   (condp = ns-symbol
+                                     'a '(ns a)
+                                     'b '(ns b)
+                                     'c '(ns c (:require b))))]
+      (t/is (= '[b c a] (cd/in-dependency-order '[a b c]))))))


### PR DESCRIPTION
This PR fixes #312.

The root cause of the issue is that if there is an "isolated" namespace (i.e. a namespace that has no dependency relation with any other namespace), `dep/in-dependency-order` ignores it.

This can be confirmed by passing the following namespace (which is "isolated" by the above definition) to `dep/in-dependency-order`:

```clojure
(ns example.core)

(defn f [x] x)
```

```clojure
(require '[cloverage.dependency :as dep])

(dep/in-dependency-order '[example.core])
;=> ()
```

The proposed patch is trying to resolve the issue by appending the isolated namespaces after the `topo-sort`ed result. The `distinct` + `concat` pattern used [here](https://github.com/athos/cloverage/blob/96d9768134e30dec63acebb52f9af382efe7720b/cloverage/src/cloverage/dependency.clj#L32-L33) can be seen [several](https://github.com/clojure/tools.namespace/blob/dd7de4deb09b1e93e13b3998fdd746edac8cabe8/src/main/clojure/clojure/tools/namespace/track.cljc#L81-L86) [times](https://github.com/clojure/tools.namespace/blob/dd7de4deb09b1e93e13b3998fdd746edac8cabe8/src/main/clojure/clojure/tools/namespace/track.cljc#L103-L109) in `tools.namespace` itself.