### PR TITLE
Make validation errors in the project settings fail Cloverage runs

### DIFF
--- a/cloverage/src/cloverage/args.clj
+++ b/cloverage/src/cloverage/args.clj
@@ -116,7 +116,8 @@
                       (update :test-selectors #(into {} %)))]
     [opts add-nses help]))
 
-(def arguments
+;; This is a defn for avoiding state across test runs
+(defn arguments []
   [["-o" "--output" "Output directory." :default "target/coverage"]
    ["--[no-]text"
     "Produce a text report." :default false]
@@ -196,5 +197,5 @@
    ["-h" "--help" "Show help." :default false :flag true]])
 
 (defn parse-args [args project-settings]
-  (fix-opts (apply cli/cli args arguments)
+  (fix-opts (apply cli/cli args (arguments))
             (doto project-settings validate!)))

--- a/cloverage/src/cloverage/args.clj
+++ b/cloverage/src/cloverage/args.clj
@@ -3,7 +3,8 @@
   (:require [clojure.tools.cli :as cli]
             [clojure.set :as set]
             [clojure.string :as str])
-  (:import (java.util.regex Pattern)))
+  (:import (java.util.regex Pattern)
+           (clojure.lang ExceptionInfo)))
 
 (defn- boolean? [x]
   (instance? Boolean x))
@@ -45,11 +46,27 @@
    :test-ns-path     regexes-or-strings?
    :custom-report    symbol?})
 
-(defn valid? [[k v :as pair]]
+(defn- fn-sym [^Object f]
+  (let [[_ f-ns f-n] (re-matches #"(.*)\$(.*?)(__[0-9]+)?" (.. f getClass getName))]
+    ;; check for anonymous function
+    (when (not= "fn" f-n)
+      (symbol (clojure.lang.Compiler/demunge f-ns) (clojure.lang.Compiler/demunge f-n)))))
+
+(defn validate [[k v :as pair]]
   (let [f (get valid k (constantly true))]
     (if (f v)
       pair
-      (println "Invalid value:" k ", " v))))
+      (let [message (str "Invalid value: " k ", " v " (should satisfy: " (fn-sym f) ")")]
+        (println message)
+        (ex-info message {:k k :v v :validation-fn (fn-sym f)})))))
+
+(defn validate! [project-settings]
+  (when-let [validation-errors (->> project-settings
+                                    (mapv validate) ;; mapv for running all validations. Printing multiple results is friendlier than just one
+                                    (filterv (partial instance? ExceptionInfo))
+                                    (not-empty))]
+    (throw (ex-info "Invalid project settings"
+                    {:invalid-pairs (mapv ex-data validation-errors)}))))
 
 (defn- collecting-args-parser []
   (let [col (atom [])]
@@ -76,13 +93,12 @@
 (defn- overwrite
   "For each key-value pair in project settings, overwrite the value in opts"
   [opts project-settings]
-  (->> project-settings
-       (keep valid?)
-       (reduce (fn [o [k v]]
-                 (if (coll? v)
-                   (update o k concat v)
-                   (assoc o k v)))
-               opts)))
+  (reduce (fn [o [k v]]
+            (if (coll? v)
+              (update o k concat v)
+              (assoc o k v)))
+          opts
+          project-settings))
 
 (defn- fix-opts
   "Clean the parsed command-line options.
@@ -180,4 +196,5 @@
    ["-h" "--help" "Show help." :default false :flag true]])
 
 (defn parse-args [args project-settings]
-  (fix-opts (apply cli/cli args arguments) project-settings))
+  (fix-opts (apply cli/cli args arguments)
+            (doto project-settings validate!)))

--- a/cloverage/test/cloverage/args_test.clj
+++ b/cloverage/test/cloverage/args_test.clj
@@ -1,7 +1,8 @@
 (ns cloverage.args-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [are deftest is testing]]
             [cloverage.args :as args]
-            [cloverage.coverage]))
+            [cloverage.coverage])
+  (:import (clojure.lang ExceptionInfo)))
 
 (deftest overwriting
   (let [output (#'args/overwrite
@@ -15,14 +16,7 @@
       (is (= '(1 2 3 4)
              (:coll output)))
       (is (= "new"
-             (:string output))))
-
-    (testing "removing the invalid keys"
-      (let [output (#'args/overwrite
-                    {}
-                    {:test-ns-regex [#"" ""]
-                     :src-ns-path   [1]})]
-        (is (nil? (find output :src-ns-path)))))))
+             (:string output))))))
 
 (deftest fixing-options
   (let [opts (first (args/parse-args ["-p" "src1"] {:src-ns-path ["src2"]}))]
@@ -52,3 +46,39 @@
           "equivalent to the expected symbol")
       (is (= 42 (cloverage.coverage/launch-custom-report crep {:args [42]}))
           "launches the custom reporter"))))
+
+(deftest validate!
+  (are [input expected] (= expected
+                           (try
+                             (args/validate! input)
+                             (catch ExceptionInfo e
+                               (is (= "Invalid project settings"
+                                      (ex-message e)))
+                               (->> e
+                                    ex-data
+                                    :invalid-pairs
+                                    (sort-by :validation-fn)))))
+    {}                                nil
+    {:custom-report 'a}               nil
+    {:custom-report "not a symbol"}   [{:validation-fn 'clojure.core/symbol?
+                                        :v             "not a symbol"
+                                        :k             :custom-report}]
+    {:ns-exclude-regex "not symbols"} [{:validation-fn 'cloverage.args/regexes-or-strings?,
+                                        :v             "not symbols",
+                                        :k             :ns-exclude-regex}]
+    {:custom-report    "not a symbol"
+     :ns-exclude-regex "not symbols"} [{:validation-fn 'clojure.core/symbol?,
+                                        :v             "not a symbol",
+                                        :k             :custom-report}
+                                       {:validation-fn 'cloverage.args/regexes-or-strings?,
+                                        :v             "not symbols",
+                                        :k             :ns-exclude-regex}]))
+
+(deftest parse-args
+  (testing "Uses validation"
+    (is (= {:invalid-pairs
+            [{:k :runner, :v 'midje, :validation-fn `keyword?}]}
+           (try
+             (args/parse-args [] {:runner 'midje})
+             (catch ExceptionInfo e
+               (ex-data e)))))))


### PR DESCRIPTION
Fixes https://github.com/cloverage/cloverage/issues/331, generalizing the notion that any validation error (and not only `:runner` ones) should fail a given run.

I verified that it works as intended over a local install.

Here is the output:

<details>

```
~/sample (master*) $ lein cloverage
Invalid value: :runner, 123 (should satisfy: clojure.core/keyword?)
clojure.lang.ExceptionInfo: Invalid project settings {:invalid-pairs [{:k :runner, :v 123, :validation-fn clojure.core/keyword?}]}
	at cloverage.args$validate_BANG_.invokeStatic(args.clj:68)
	at cloverage.args$validate_BANG_.invoke(args.clj:63)
	at cloverage.args$parse_args.invokeStatic(args.clj:201)
	at cloverage.args$parse_args.invoke(args.clj:199)
	at cloverage.coverage$run_project.invokeStatic(coverage.clj:322)
	at cloverage.coverage$run_project.doInvoke(coverage.clj:319)
	at clojure.lang.RestFn.invoke(RestFn.java:410)
	at user$eval4186.invokeStatic(form-init15952895222665977540.clj:1)
	at user$eval4186.invoke(form-init15952895222665977540.clj:1)
	at clojure.lang.Compiler.eval(Compiler.java:7177)
	at clojure.lang.Compiler.eval(Compiler.java:7167)
	at clojure.lang.Compiler.load(Compiler.java:7636)
	at clojure.lang.Compiler.loadFile(Compiler.java:7574)
	at clojure.main$load_script.invokeStatic(main.clj:475)
	at clojure.main$init_opt.invokeStatic(main.clj:477)
	at clojure.main$init_opt.invoke(main.clj:477)
	at clojure.main$initialize.invokeStatic(main.clj:508)
	at clojure.main$null_opt.invokeStatic(main.clj:542)
	at clojure.main$null_opt.invoke(main.clj:539)
	at clojure.main$main.invokeStatic(main.clj:664)
	at clojure.main$main.doInvoke(main.clj:616)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at clojure.lang.Var.applyTo(Var.java:705)
	at clojure.main.main(main.java:40)
{:clojure.main/message
 "Syntax error (ExceptionInfo) compiling at (/private/var/folders/yc/h50n8fgn0h79y848sfkr942h0000gn/T/form-init15952895222665977540.clj:1:126).\nInvalid project settings\n",
 :clojure.main/triage
 {:clojure.error/phase :compile-syntax-check,
  :clojure.error/line 1,
  :clojure.error/column 126,
  :clojure.error/source "form-init15952895222665977540.clj",
  :clojure.error/path
  "/private/var/folders/yc/h50n8fgn0h79y848sfkr942h0000gn/T/form-init15952895222665977540.clj",
  :clojure.error/class clojure.lang.ExceptionInfo,
  :clojure.error/cause "Invalid project settings"},
 :clojure.main/trace
 {:via
  [{:type clojure.lang.Compiler$CompilerException,
    :message
    "Syntax error compiling at (/private/var/folders/yc/h50n8fgn0h79y848sfkr942h0000gn/T/form-init15952895222665977540.clj:1:126).",
    :data
    {:clojure.error/phase :compile-syntax-check,
     :clojure.error/line 1,
     :clojure.error/column 126,
     :clojure.error/source
     "/private/var/folders/yc/h50n8fgn0h79y848sfkr942h0000gn/T/form-init15952895222665977540.clj"},
    :at [clojure.lang.Compiler load "Compiler.java" 7648]}
   {:type clojure.lang.ExceptionInfo,
    :message "Invalid project settings",
    :data
    {:invalid-pairs
     [{:k :runner, :v 123, :validation-fn clojure.core/keyword?}]},
    :at [cloverage.args$validate_BANG_ invokeStatic "args.clj" 68]}],
  :trace
  [[cloverage.args$validate_BANG_ invokeStatic "args.clj" 68]
   [cloverage.args$validate_BANG_ invoke "args.clj" 63]
   [cloverage.args$parse_args invokeStatic "args.clj" 201]
   [cloverage.args$parse_args invoke "args.clj" 199]
   [cloverage.coverage$run_project invokeStatic "coverage.clj" 322]
   [cloverage.coverage$run_project doInvoke "coverage.clj" 319]
   [clojure.lang.RestFn invoke "RestFn.java" 410]
   [user$eval4186 invokeStatic "form-init15952895222665977540.clj" 1]
   [user$eval4186 invoke "form-init15952895222665977540.clj" 1]
   [clojure.lang.Compiler eval "Compiler.java" 7177]
   [clojure.lang.Compiler eval "Compiler.java" 7167]
   [clojure.lang.Compiler load "Compiler.java" 7636]
   [clojure.lang.Compiler loadFile "Compiler.java" 7574]
   [clojure.main$load_script invokeStatic "main.clj" 475]
   [clojure.main$init_opt invokeStatic "main.clj" 477]
   [clojure.main$init_opt invoke "main.clj" 477]
   [clojure.main$initialize invokeStatic "main.clj" 508]
   [clojure.main$null_opt invokeStatic "main.clj" 542]
   [clojure.main$null_opt invoke "main.clj" 539]
   [clojure.main$main invokeStatic "main.clj" 664]
   [clojure.main$main doInvoke "main.clj" 616]
   [clojure.lang.RestFn applyTo "RestFn.java" 137]
   [clojure.lang.Var applyTo "Var.java" 705]
   [clojure.main main "main.java" 40]],
  :cause "Invalid project settings",
  :data
  {:invalid-pairs
   [{:k :runner, :v 123, :validation-fn clojure.core/keyword?}]},
  :phase :compile-syntax-check}}

Syntax error (ExceptionInfo) compiling at (/private/var/folders/yc/h50n8fgn0h79y848sfkr942h0000gn/T/form-init15952895222665977540.clj:1:126).
Invalid project settings

~/sample (master*) $ echo $?
1
```

</details>

And I got a green build in my account:

<img width="756" alt="image" src="https://user-images.githubusercontent.com/1162994/169889573-fbe8c358-674b-4674-8620-30074c751c7f.png">

Cheers - V