### PR TITLE
Introduce a CI matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,67 +1,98 @@
-version: 2.0
-jobs:
-  build:
+version: 2.1
+
+executors:
+  openjdk8:
     docker:
-      - image: clojure:lein-2.9.1
+      - image: circleci/clojure:openjdk-8-lein-2.9.1-node
+    environment:
+      LEIN_ROOT: "true"
+      JVM_OPTS: -Xmx3200m
+
+  openjdk11:
+    docker:
+      - image: circleci/clojure:openjdk-11-lein-2.9.3-buster-node
+    environment:
+      LEIN_ROOT: "true"
+      JVM_OPTS: -Xmx3200m --illegal-access=deny
+
+  openjdk17:
+    docker:
+      - image: circleci/clojure:openjdk-17-lein-2.9.5-buster-node
+    environment:
+      LEIN_ROOT: "true"
+      JVM_OPTS: -Xmx3200m
+
+jobs:
+  run_command:
+    parameters:
+      jdk_version:
+        type: string
+      clojure_version:
+        type: string
+      working_directory:
+        type: string
+      command:
+        type: string
+    executor: << parameters.jdk_version >>
+    environment:
+      CLOJURE_VERSION: << parameters.clojure_version >>
     steps:
       - checkout
-
-      ################################################################################
-      # setup dependencies
-
       - restore_cache:
           keys:
-            - v1-jars-{{ checksum "cloverage/project.clj" }}-{{ checksum "lein-cloverage/project.clj" }}
-            - v1-jars-
+            - v1-dependencies-<< parameters.clojure_version >>-<< parameters.command >>-{{ checksum "<< parameters.working_directory >>/project.clj" }}
+            - v1-dependencies-<< parameters.clojure_version >>-<< parameters.command >>
+            - v1-dependencies-<< parameters.clojure_version >>
+            - v1-dependencies-
       - run:
-          name: (cloverage) install dependencies
-          command: lein deps
-          working_directory: ./cloverage
-      - run:
-          name: (lein-cloverage) install dependencies
-          command: lein deps
-          working_directory: ./lein-cloverage
+          working_directory: << parameters.working_directory >>
+          command: lein with-profile +dev,+test,+eastwood,+<< parameters.clojure_version >> deps
       - save_cache:
-          key: v1-jars-{{ checksum "cloverage/project.clj" }}-{{ checksum "lein-cloverage/project.clj" }}
           paths:
             - ~/.m2
+          key: v1-dependencies-<< parameters.clojure_version >>-<< parameters.command >>-{{ checksum "<< parameters.working_directory >>/project.clj" }}
+      - run:
+          working_directory: << parameters.working_directory >>
+          command: lein << parameters.command >>
 
-      ################################################################################
-      # cloverage tests
+filters: &filters
+  branches:
+    only: /.*/
+  tags:
+    only: /^v\d+\.\d+\.\d+(-alpha\d+)?$/
 
-      - run:
-          name: (cloverage) tests
-          command: lein kaocha
-          working_directory: ./cloverage
-      - run:
-          name: (cloverage) cljfmt
-          command: lein cljfmt check
-          working_directory: ./cloverage
-      - run:
-          name: (cloverage) eastwood
-          command: lein eastwood
-          working_directory: ./cloverage
-      - run:
-          name: (cloverage) kibit
-          command: lein kibit
-          working_directory: ./cloverage
-
-      ################################################################################
-      # lein-cloverage tests
-
-      - run:
-          name: (lein-cloverage) tests
-          command: lein test
-          working_directory: ./lein-cloverage
-      - run:
-          name: (lein-cloverage) cljfmt
-          command: lein cljfmt check
-          working_directory: ./lein-cloverage
-      - run:
-          name: (lein-cloverage) eastwood
-          command: lein eastwood
-          working_directory: ./lein-cloverage
-      - run:
-          name: (lein-cloverage) kibit
-          command: lein kibit
-          working_directory: ./lein-cloverage
+workflows:
+  version: 2.1
+  ci-test-matrix:
+    jobs:
+      - run_command:
+          # Full test matrix for the .cloverage project - it has all logic, so it deserves to be exercised exhaustively.
+          # Eastwood also benefits from being run in different environments.
+          matrix:
+            parameters:
+              clojure_version: ["1.8", "1.9", "1.10", "1.11"]
+              jdk_version: [openjdk8, openjdk11, openjdk17]
+              working_directory: ["./cloverage"]
+              command: ["test-ci", "eastwood-ci"]
+          filters:
+            <<: *filters
+      - run_command:
+         # Limited test matrix for the .lein-cloverage project - it has little logic so exercising extra clojure versions is not necessary.
+          matrix:
+            parameters:
+              clojure_version: ["1.11"]
+              jdk_version: [openjdk8, openjdk11, openjdk17]
+              working_directory: ["./lein-cloverage"]
+              command: ["test-ci", "eastwood-ci"]
+          filters:
+            <<: *filters
+      - run_command:
+          # Very limited matrix for static linters which do not benefit from being run in additional runtimes.
+          matrix:
+            parameters:
+              clojure_version: ["1.11"]
+              jdk_version: [openjdk17]
+              working_directory: ["./cloverage",  "./lein-cloverage"]
+              command: ["cljfmt check", "kibit"]
+          filters:
+            <<: *filters

--- a/cloverage/project.clj
+++ b/cloverage/project.clj
@@ -1,3 +1,7 @@
+(def clojure-profile (if (System/getenv "CI")
+                       (-> "CLOJURE_VERSION" System/getenv not-empty (doto (assert "CLOJURE_VERSION is unset!")))
+                       "1.11"))
+
 (defproject cloverage "1.2.4-SNAPSHOT"
   :description "Form-level test coverage for clojure."
   :url "https://www.github.com/cloverage/cloverage"
@@ -13,37 +17,53 @@
             :comments "same as Clojure"}
   :deploy-repositories [["releases" :clojars]
                         ["snapshots" :clojars]]
-  :dependencies [[org.clojure/tools.reader "1.3.6"]
+  :dependencies [[org.clojure/clojure "1.11.1" :scope "provided"]
+                 [org.clojure/tools.reader "1.3.6"]
                  [org.clojure/tools.cli "0.4.2"]
                  [org.clojure/tools.logging "0.5.0"]
                  [org.clojure/tools.namespace "1.3.0"]
                  [org.clojure/java.classpath "1.0.0"]
                  [org.clojure/data.xml "0.2.0-alpha6"]
-                 [org.clojure/data.json "2.4.0"]
+                 [org.clojure/data.json "2.4.0" :exclusions [org.clojure/clojure]]
                  [riddley "0.2.0"]
                  [slingshot "0.12.2"]]
   :profiles {:dev {:aot ^:replace []
-                   :dependencies [[org.clojure/clojure "1.11.1"]
-                                  [lambdaisland/kaocha "1.0.887"]
-                                  [lambdaisland/kaocha-cloverage "1.0.75"]
-                                  [pjstadig/humane-test-output "0.11.0"]]
-                   :injections [(require 'pjstadig.humane-test-output)
-                                (pjstadig.humane-test-output/activate!)]
                    :plugins [[lein-cljfmt "0.8.0"]
-                             [jonase/eastwood "1.2.3"]
                              [lein-kibit "0.1.8"]]
                    :global-vars {*warn-on-reflection* true}
                    :resource-paths ["dev-resources"]
                    :source-paths ["repl" "sample"]}
-             :1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}
-             :1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
-             :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
-             :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
              :1.10 {:dependencies [[org.clojure/clojure "1.10.3"]]}
              :1.11 {:dependencies [[org.clojure/clojure "1.11.1"]]}
-             :test {:source-paths ["sample"]
-                    :jvm-opts ["-Duser.language=en-US"]}}
-  :aliases {"all" ["with-profile" "+1.4:+1.5:+1.6:+1.7:+1.8:+1.9:+1.10:+1.11"]
-            "kaocha" ["with-profile" "dev" "run" "-m" "kaocha.runner"]})
+             :eastwood {:plugins [[jonase/eastwood "1.2.3"]]
+                        :eastwood {:ignored-faults {:implicit-dependencies {cloverage.report.emma-xml ~(case clojure-profile
+                                                                                                         ("1.8" "1.9") [{:line 42}]
+                                                                                                         [])}}}}
+             :humane {:dependencies [[pjstadig/humane-test-output "0.11.0"]]
+                      :injections [(require 'pjstadig.humane-test-output)
+                                   (pjstadig.humane-test-output/activate!)]}
+             :test {:aot ^:replace []
+                    :dependencies [[lambdaisland/kaocha "1.0.887" :exclusions [org.clojure/tools.cli
+                                                                               org.clojure/clojure
+                                                                               org.clojure/spec.alpha]]
+                                   [lambdaisland/kaocha-cloverage "1.0.75" :exclusions [org.clojure/clojure
+                                                                                        org.clojure/spec.alpha]]]
+                    :source-paths ["sample"]
+                    :jvm-opts ["-Duser.language=en-US"]}
+             :ci {:pedantic? :abort}}
+  :aliases {"all" ["with-profile" "+1.8:+1.9:+1.10:+1.11"]
+            "kaocha" ["test-ci"]
+            "eastwood-ci" ["with-profile"
+                           ~(str "-dev,+test,+ci,+eastwood,+" clojure-profile)
+                           "eastwood"]
+            "test-ci" ~(if (= "1.8" clojure-profile)
+                         ["with-profile"
+                          (str "-dev,+test,+ci,+" clojure-profile)
+                          "test"]
+                         ["with-profile"
+                          (str "-dev,+test,+ci,+" clojure-profile)
+                          "run"
+                          "-m"
+                          "kaocha.runner"])})

--- a/cloverage/test/cloverage/args_test.clj
+++ b/cloverage/test/cloverage/args_test.clj
@@ -53,7 +53,7 @@
                              (args/validate! input)
                              (catch ExceptionInfo e
                                (is (= "Invalid project settings"
-                                      (ex-message e)))
+                                      (.getMessage e)))
                                (->> e
                                     ex-data
                                     :invalid-pairs

--- a/cloverage/test/cloverage/dependency_test.clj
+++ b/cloverage/test/cloverage/dependency_test.clj
@@ -77,7 +77,8 @@
     (t/testing ns-name
       (with-redefs [source/ns-form (constantly ns-form)]
         (t/is (= expected
-                 (#'cd/dependencies (symbol ns-name))))))))
+                 (#'cd/dependencies (symbol (namespace ns-name)
+                                            (name ns-name)))))))))
 
 (t/deftest test-dependency-sort
   (t/is (= '[clojure.walk

--- a/lein-cloverage/project.clj
+++ b/lein-cloverage/project.clj
@@ -10,10 +10,13 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"
             :distribution :repo
             :comments "same as Clojure"}
+  :dependencies [[org.clojure/clojure "1.11.1" :scope "provided"]]
   :deploy-repositories [["releases" :clojars]
                         ["snapshots" :clojars]]
   :lein-release {:scm :git ; Because we're not in the top-level directory, so it doesn't auto-detect
                  :deploy-via :clojars}
+  :aliases {"test-ci" ["with-profile" "-dev,+test,+ci" "test"]
+            "eastwood-ci" ["with-profile" "-dev,+test,+ci" "eastwood"]}
   :release-tasks [["vcs" "assert-committed"]
                   ["change" "version" "leiningen.release/bump-version" "release"]
                   ["vcs" "commit"]
@@ -30,5 +33,6 @@
   :min-lein-version "2.0.0"
   :profiles {:dev {:plugins [[lein-cljfmt "0.6.4"]
                              [jonase/eastwood "1.2.3"]
-                             [lein-kibit "0.1.7"]]}}
+                             [lein-kibit "0.1.7"]]}
+             :ci {:pedantic? :abort}}
   :eval-in-leiningen true)


### PR DESCRIPTION
Introduces a comprehensive CI matrix so that we can iterate more reliably.

Also introduces `:pedantic?`, tweaking some dependencies accordingly.

Starts running `lein test` (as opposed to `lein kaocha`) for older versions of Clojure - where Kaocha is unsupported.

Care has been taken not to run redundant matrix combinations, e.g. cljfmt will have identical results no matter the JDK or clojure versions.

I verified that .m2 caching works:

<img width="1041" alt="image" src="https://user-images.githubusercontent.com/1162994/170048629-c4390290-1f13-4d61-b928-f11e2e2f66a2.png">

And the overall matrix is green:

<img width="590" alt="image" src="https://user-images.githubusercontent.com/1162994/170048910-dc816662-30fa-4ff9-87c8-2559968ccecf.png">

Cheers - V