### PR TITLE
Resolve the :report runner-opt for :eftest when it is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ in github. Commentary on the change should appear as a nested, unordered list. -
 
 ## 1.2.5 (WIP)
 
-Nothing yet!
+- Resolve `[:runner-opt :report]` in the eftest runner
+  - Fixes [#328](https://github.com/cloverage/cloverage/issues/328)
 
 ## 1.2.4
 

--- a/cloverage/src/cloverage/coverage.clj
+++ b/cloverage/src/cloverage/coverage.clj
@@ -227,6 +227,9 @@
                                (not (map? runner-opts)))
                         (into {} runner-opts)
                         runner-opts)
+          eftest-opts (cond-> eftest-opts
+                        (contains? eftest-opts :report)
+                        (update :report resolve-var))
           extra-test-ns (or (seq (:extra-test-ns opts)) [])
           test-namespaces (->> (find-nses (:test-ns-path opts) (:test-ns-regex opts))
                                (concat extra-test-ns)

--- a/cloverage/test/cloverage/coverage_test.clj
+++ b/cloverage/test/cloverage/coverage_test.clj
@@ -448,4 +448,17 @@
                       cov/require-ns (constantly "test")
                       require (constantly nil)]
           (t/is (= {:errors 3}
+                   ((cov/runner-fn (merge opts runner-opts)) []))))))
+    (t/testing "check that eftest runner-fn passes the :report runner-opt as a function"
+      (let [runner-opts {:runner-opts {:test-warn-time 100
+                                       :multithread? false
+                                       :report 'custom/report}}]
+        (with-redefs [cov/resolve-var {'eftest.runner/find-tests (constantly [])
+                                       'eftest.runner/run-tests (fn [_ {:keys [report]}]
+                                                                  (report {:error 0 :fail 1}))
+                                       'custom/report identity}
+                      cov/find-nses (constantly [])
+                      cov/require-ns (constantly "test")
+                      require (constantly nil)]
+          (t/is (= {:errors 1}
                    ((cov/runner-fn (merge opts runner-opts)) []))))))))


### PR DESCRIPTION
Eftest supports configurable runners, but it expects the :report option to contain a function and not a symbol.

- [X] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
