### PR TITLE
Add `--selector` flag to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Available options and command-line arguments:
  :src-ns-path      -p, --src-ns-path            []               Path (string) to directory containing source code namespaces (can be repeated).
  :test-ns-path     -s, --test-ns-path           []               Path (string) to directory containing test namespaces (can be repeated).
  :extra-test-ns    -x, --extra-test-ns          []               Additional test namespace (string) to add (can be repeated).
+ :selector         --selector                   []               Apply test selector (can be repeated).
  :custom-report    -c, --custom-report                           Load and run a custom report writer. Should be a namespaced symbol. The function is passed
     project-options args-map output-directory forms
  :help?            -h, --no-help, --help        false            Show help.


### PR DESCRIPTION
The feature was implemented a few years ago and it was not documented.

- https://github.com/cloverage/cloverage/pull/230
- https://github.com/cloverage/cloverage/blob/master/cloverage/src/cloverage/args.clj#L189-L192

I think that this `--selector` flags only works with `clojure.test` runner. I'm not sure about it. If so, I think it's worth adding a comment about it.


- [ ] You've updated the [changelog](../blob/master/CHANGELOG.md) (if adding/changing user-visible functionality)
