### PR TITLE
Use relative source file paths n Codevoc.io report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ in github. Commentary on the change should appear as a nested, unordered list. -
 - Add support for Clojure 1.12
   - Fixes [#345](https://github.com/cloverage/cloverage/issues/345)
   - Fixes [#347](https://github.com/cloverage/cloverage/issues/347)
+- Use relative source file paths in Codecov.io report
 
 ## 1.2.4
 

--- a/cloverage/src/cloverage/report/codecov.clj
+++ b/cloverage/src/cloverage/report/codecov.clj
@@ -2,7 +2,8 @@
   (:require
    [clojure.java.io :as io]
    [clojure.data.json :as json]
-   [cloverage.report :refer [line-stats with-out-writer]]))
+   [cloverage.report :refer [line-stats with-out-writer]]
+   [cloverage.source :refer [source-file-path]]))
 
 (defn- file-coverage [[file file-forms]]
   ;; https://codecov.io/api#post-json-report
@@ -11,7 +12,7 @@
   ;; 0: not covered
   ;; null: skipped/ignored/empty
   ;; the first item in the list must be a null
-  (vector file
+  (vector (source-file-path file)
           (cons nil
                 (mapv (fn [line]
                         (cond (:blank?   line) nil


### PR DESCRIPTION
### Problem
The Codecov.io report currently uses classpath-relative file paths when reporting coverage. This can lead to ambiguous file references in Clojure projects, since it's possible to have the same relative path in multiple classpath entries. For example, both `src/foo/core.clj` and `dev/foo/core.clj` could result in the same `foo/core.clj` path in the report.

This ambiguity causes issues for tools that consume the Codecov.io report. In particular, the [SonarClojure plugin](https://github.com/fsantiag/sonar-clojure) may fail to produce the coverage report when it cannot uniquely resolve a file path due to multiple matches.

### Solution
This PR updates Cloverage to use project-relative source file paths (e.g., `src/foo/core.clj`) instead of classpath-relative ones. These paths uniquely identify files within the project directory and eliminate ambiguity for downstream tools.