### PR TITLE
Switch bb tests to stable babashka release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,8 +109,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install babashka (dev build)
-        run: bash <(curl -sL https://raw.githubusercontent.com/babashka/babashka/master/install) --dev-build
+      - uses: DeLaGuardo/setup-clojure@13.5
+        with:
+          bb: latest
       - uses: actions/cache@v4
         with:
           path: |


### PR DESCRIPTION
## Summary

- Replace dev build babashka install script with `DeLaGuardo/setup-clojure` using `bb: latest`, now that a stable babashka release includes the relevant fixes

Closes #360

## Test plan

- [ ] Verify the `bb-test` CI job passes with the stable babashka release

🤖 Generated with [Claude Code](https://claude.com/claude-code)